### PR TITLE
Implement skeleton of CLI through `ricer::cli` module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,7 +521,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "ricer"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/rice-configs/ricer"
 authors = ["Jason Pena <jasonpena@awkless.com>"]
 edition = "2021"
 license = "GPL-2.0-or-later WITH GPL-CC-1.0"
-version = "0.1.1"
+version = "0.2.0"
 rust-version = "1.74.1"
 
 [lib]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -68,7 +68,7 @@ impl Cli {
             .init();
 
         let out = match args.cmd {
-            _ => todo!()
+            _ => todo!(),
         };
 
         Ok(out)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -68,7 +68,7 @@ impl Cli {
             .init();
 
         let out = match args.cmd {
-            _ => todo!(),
+            CommandSet::Init => "todo".to_string(),
         };
 
         Ok(out)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,7 +30,47 @@ pub struct Cli {
 }
 
 impl Cli {
+    /// Parse and execute command set.
+    ///
+    /// Constructs new instance of Ricer's CLI, then parses and executes the
+    /// command-line arguments the user passes in. If no errors occur, then this
+    /// method provides any output that needs to be written to stdout.
+    /// Otherwise, this method provides any output that details what went wrong
+    /// for stderr.
+    ///
+    /// # Preconditions
+    ///
+    /// 1. User provides correct commands and arguments to execute.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Execute command with any arguments user passed.
+    /// 1. Initialize logger to report what the Ricer binary is doing depending
+    ///    on the verbosity level set by the user.
+    ///
+    /// # Invariants
+    ///
+    /// 1. Do not let `main` panic.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ricer::cli::Cli
+    ///
+    /// let out = Cli::new_run().expect("Failed to run Ricer");
+    /// println!("{}", out);
+    /// ```
     pub fn new_run() -> Result<String> {
-        todo!();
+        let args = Cli::parse();
+        env_logger::Builder::new()
+            .format_timestamp(None)
+            .filter_level(args.verbose.log_level_filter())
+            .init();
+
+        let out = match args.cmd {
+            _ => todo!()
+        };
+
+        Ok(out)
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use clap_verbosity_flag::{InfoLevel, Verbosity};
+
+/// Current command set of Ricer.
+#[derive(Debug, Subcommand)]
+pub enum CommandSet {
+    /// Initialize a new "fake-bare" Git repository.
+    Init,
+}
+
+/// Command-line interface.
+///
+/// Parses and executes the command-line arguments passed to the Ricer binary by
+/// the user. Provides a git-like interface, with specialized commands to make
+/// it easier to manage and organize rice configurations. See [`CommandSet`] for
+/// full command set that Ricer's interface offers.
+#[derive(Debug, Parser)]
+pub struct Cli {
+    // Control log level of binary...
+    #[command(flatten)]
+    verbose: Verbosity<InfoLevel>,
+
+    // Link command set...
+    #[command(subcommand)]
+    cmd: CommandSet,
+}
+
+impl Cli {
+    pub fn new_run() -> Result<String> {
+        todo!();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,42 @@
 
 //! Welcome to Ricer's internal API!
 //!
-//! TODO: Document future modules...
+//! If you plan on contributing to Ricer, then you came to the right place! The
+//! documentation stored here explains the _what_ and _why_. However, if you
+//! want to find out about the _how_, then you need to look at the code itself!
+//! Visit <https://github.com/rice-configs/ricer> for the code.
+//!
+//! # What is Ricer?
+//!
+//! Ricer is an experimental command-line tool designed for managing and
+//! organizing [rice][explain-rice] configurations through [Git][git-scm]. Ricer
+//! allows the user to treat their home directory like a regular Git directory.
+//! Each configuration the user has will get stuffed into their own "fake-bare"
+//! repository. The "fake-bare" repository system allows the user to modularize
+//! their configurations for easier deployment across multiple machines.
+//!
+//! If Ricer's behavior seems familiar, then that is because Ricer borrows many
+//! concepts from [vcsh][vcsh-repo]. In fact, one could argue that Ricer is the
+//! Rust version of [vcsh][vcsh-repo]. Although Ricer attempts to combine
+//! [vcsh][vcsh-repo] and [mr][mr-repo] under one neat little program in Rust.
+//!
+//! # Contributing
+//!
+//! The Ricer coding project is open to the following forms of contribution:
+//!
+//! 1. Improvements or additions to production code.
+//! 1. Improvements or additions to test code.
+//! 1. Improvements or additions to build system.
+//! 1. Improvements or additions to documentation.
+//! 1. Improvements or additions to CI/CD pipelines.
+//!
+//! See the [contribution guidelines][contrib-guide] for more information about
+//! contributing to the Ricer project.
+//!
+//! [explain-ricing]: pesos.github.io/2020/07/14/what-is-ricing.html
+//! [git-scm]: https://git-scm.com
+//! [vcsh-repo]: https://github.com/RichiH/vcsh
+//! [mr-repo]: https://github.com/RichiH/myrepos
+//! [contrib-guide]: CONTRIBUTING.md
 
-// TODO: Put future modules here...
+// TODO: Link modules...

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,4 +41,5 @@
 //! [mr-repo]: https://github.com/RichiH/myrepos
 //! [contrib-guide]: CONTRIBUTING.md
 
-// TODO: Link modules...
+/// CLI implementation.
+pub mod cli;

--- a/src/ricer.rs
+++ b/src/ricer.rs
@@ -1,6 +1,21 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
 
-fn main() {
-    println!("Hello from Ricer!");
+use log::{error, info};
+use std::process::ExitCode;
+
+use ricer::cli::Cli;
+
+fn main() -> ExitCode {
+    match Cli::new_run() {
+        Ok(out) => {
+            info!("{}", out);
+            ExitCode::SUCCESS
+        }
+
+        Err(error) => {
+            error!("{}", error);
+            ExitCode::FAILURE
+        }
+    }
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

Setup basic skeleton of CLI to begin implementing future command set.

## Area of Effect

- Module `ricer::cli`.
