### PR TITLE
Setup context layer

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -199,7 +199,7 @@ pub enum CommandSet {
 
     /// Run user's Git binary on target repository.
     #[command(external_subcommand)]
-    UseGitBinOnRepo(Vec<OsString>),
+    RepoGit(Vec<OsString>),
 }
 
 /// Options for commit command.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,7 +43,9 @@
 //! external subcommand shortcut to the user.
 
 use crate::build;
-use clap::{Args, Parser, Subcommand, ValueEnum};
+use crate::context::HookAction;
+use crate::context::commit::FixupAction;
+use clap::{Args, Parser, Subcommand};
 use clap_verbosity_flag::{InfoLevel, Verbosity};
 use const_format::formatcp;
 use indoc::indoc;
@@ -73,7 +75,7 @@ pub struct RicerCli {
 
     /// Options that are shareable across Ricer commands.
     #[command(flatten)]
-    pub cmd_opts: CommandOpts,
+    pub shared_opts: SharedOpts,
 
     /// Ricer command set.
     #[command(subcommand)]
@@ -118,47 +120,12 @@ impl RicerCli {
 /// Shareable top-level options used by all Ricer commands.
 #[derive(Debug, Args)]
 #[command(next_help_heading = "Command Options")]
-pub struct CommandOpts {
-    /// Tell Ricer how you want a command hook to be executed.
-    #[arg(
-        default_value_t = RunHookOpts::Prompt,
-        long, short = 'c',
-        value_enum,
-        value_name = "ACTION"
-    )]
-    pub run_cmd_hook: RunHookOpts,
-
-    /// Tell Ricer how you want a repository hook to be executed.
-    #[arg(
-        default_value_t = RunHookOpts::Prompt,
-        long,
-        short = 'r',
-        value_enum,
-        value_name = "ACTION"
-    )]
-    pub run_repo_hook: RunHookOpts,
+pub struct SharedOpts {
+    /// Tell Ricer how you want hooks to be executed.
+    #[arg(default_value_t = HookAction::Prompt, value_enum, value_name = "ACTION")]
+    pub run_hook: HookAction,
 }
 
-/// Hook execution options.
-///
-/// Hooks pose as a potential security risk to a user. The user is expected to
-/// know what __any__ hook is doing _before_ executing it, because Ricer does
-/// not provide any way to verify if it is safe to run. However, Ricer does try
-/// to help by offering options in executing a hook. The default behavior is to
-/// show the user the contents of a given hook and prompt them about executing
-/// it. Otherwise, they can choose never to run a hook or always execute a hook
-/// with no prompting.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
-pub enum RunHookOpts {
-    /// Run the hook no questions asked.
-    Always,
-
-    /// Show the user the contents of the hook and prompt them to execute it.
-    Prompt,
-
-    /// Do not the execute the hook.
-    Never,
-}
 
 /// Current Ricer command set.
 ///
@@ -206,22 +173,12 @@ pub enum CommandSet {
 #[derive(Args, Debug)]
 pub struct CommitOpts {
     /// Amend or reword current commit.
-    #[arg(long, short, value_enum)]
-    pub fixup: Option<FixupOpts>,
+    #[arg(long, short, value_name = "ACTION", value_enum)]
+    pub fixup: Option<FixupAction>,
 
     /// Use MSG as the commit message.
     #[arg(long, short, value_name = "MSG")]
     pub message: Option<String>,
-}
-
-/// Fixup flag options for commit command.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
-pub enum FixupOpts {
-    /// Ammend the changes made by the current commit.
-    Amend,
-
-    /// Reword the current commit.
-    Reword,
 }
 
 /// Options for push command.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,8 +43,8 @@
 //! external subcommand shortcut to the user.
 
 use crate::build;
-use crate::context::HookAction;
 use crate::context::commit::FixupAction;
+use crate::context::HookAction;
 use clap::{Args, Parser, Subcommand};
 use clap_verbosity_flag::{InfoLevel, Verbosity};
 use const_format::formatcp;
@@ -125,7 +125,6 @@ pub struct SharedOpts {
     #[arg(default_value_t = HookAction::Prompt, value_enum, value_name = "ACTION")]
     pub run_hook: HookAction,
 }
-
 
 /// Current Ricer command set.
 ///

--- a/src/context.rs
+++ b/src/context.rs
@@ -27,26 +27,26 @@ pub mod clone;
 pub mod commit;
 pub mod delete;
 pub mod enter;
-pub mod repo_git;
 pub mod init;
 pub mod list;
 pub mod pull;
 pub mod push;
 pub mod rename;
+pub mod repo_git;
 pub mod status;
 
-use crate::cli::{CommandSet, SharedOpts, RicerCli};
+use crate::cli::{CommandSet, RicerCli, SharedOpts};
 use clap::ValueEnum;
 use clone::CloneContext;
 use commit::CommitContext;
 use delete::DeleteContext;
 use enter::EnterContext;
-use repo_git::RepoGitContext;
 use init::InitContext;
 use list::ListContext;
 use pull::PullContext;
 use push::PushContext;
 use rename::RenameContext;
+use repo_git::RepoGitContext;
 use status::StatusContext;
 
 /// Context states for each Ricer command.
@@ -78,7 +78,7 @@ impl From<RicerCli> for Context {
             CommandSet::Status(_) => Self::Status(StatusContext::from(opts)),
             CommandSet::List(_) => Self::List(ListContext::from(opts)),
             CommandSet::Enter(_) => Self::Enter(EnterContext::from(opts)),
-            CommandSet::RepoGit(_) => Self::RepoGit(RepoGitContext::from(opts))
+            CommandSet::RepoGit(_) => Self::RepoGit(RepoGitContext::from(opts)),
         }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -9,16 +9,22 @@
 //! command set allowing for free modifications to Ricer's CLI without the need
 //! to modify the existing internal interface for the command set.
 
+/// Context state for commit command.
+pub mod commit;
+
 use crate::cli::{CommandSet, RicerCli};
+use commit::CommitContext;
 
 /// Context states for each Ricer command.
 #[derive(Debug)]
 pub enum Context {
+    Commit(CommitContext),
 }
 
 impl From<RicerCli> for Context {
     fn from(opts: RicerCli) -> Self {
         let ctx = match opts.cmd_set {
+            CommandSet::Commit(_) => Self::Commit(CommitContext::from(opts)),
             _ => todo!(),
         };
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -17,6 +17,7 @@ pub mod clone;
 pub mod delete;
 pub mod rename;
 pub mod status;
+pub mod list;
 
 use crate::cli::{CommandSet, RicerCli};
 use commit::CommitContext;
@@ -27,6 +28,7 @@ use clone::CloneContext;
 use delete::DeleteContext;
 use rename::RenameContext;
 use status::StatusContext;
+use list::ListContext;
 
 /// Context states for each Ricer command.
 #[derive(Debug)]
@@ -39,6 +41,7 @@ pub enum Context {
     Delete(DeleteContext),
     Rename(RenameContext),
     Status(StatusContext),
+    List(ListContext),
 }
 
 impl From<RicerCli> for Context {
@@ -52,6 +55,7 @@ impl From<RicerCli> for Context {
             CommandSet::Delete(_) => Self::Delete(DeleteContext::from(opts)),
             CommandSet::Rename(_) => Self::Rename(RenameContext::from(opts)),
             CommandSet::Status(_) => Self::Status(StatusContext::from(opts)),
+            CommandSet::List(_) => Self::List(ListContext::from(opts)),
             _ => todo!(),
         };
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -12,11 +12,13 @@
 pub mod commit;
 pub mod push;
 pub mod pull;
+pub mod init;
 
 use crate::cli::{CommandSet, RicerCli};
 use commit::CommitContext;
 use push::PushContext;
 use pull::PullContext;
+use init::InitContext;
 
 /// Context states for each Ricer command.
 #[derive(Debug)]
@@ -24,6 +26,7 @@ pub enum Context {
     Commit(CommitContext),
     Push(PushContext),
     Pull(PullContext),
+    Init(InitContext),
 }
 
 impl From<RicerCli> for Context {
@@ -32,6 +35,7 @@ impl From<RicerCli> for Context {
             CommandSet::Commit(_) => Self::Commit(CommitContext::from(opts)),
             CommandSet::Push(_) => Self::Push(PushContext::from(opts)),
             CommandSet::Pull(_) => Self::Pull(PullContext::from(opts)),
+            CommandSet::Init(_) => Self::Init(InitContext::from(opts)),
             _ => todo!(),
         };
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -19,6 +19,7 @@ pub mod rename;
 pub mod status;
 pub mod list;
 pub mod enter;
+pub mod git_on_repo;
 
 use crate::cli::{CommandSet, RicerCli};
 use commit::CommitContext;
@@ -31,6 +32,7 @@ use rename::RenameContext;
 use status::StatusContext;
 use list::ListContext;
 use enter::EnterContext;
+use git_on_repo::UseGitBinOnRepoContext;
 
 /// Context states for each Ricer command.
 #[derive(Debug)]
@@ -45,6 +47,7 @@ pub enum Context {
     Status(StatusContext),
     List(ListContext),
     Enter(EnterContext),
+    UseGitBinOnRepo(UseGitBinOnRepoContext),
 }
 
 impl From<RicerCli> for Context {
@@ -60,7 +63,7 @@ impl From<RicerCli> for Context {
             CommandSet::Status(_) => Self::Status(StatusContext::from(opts)),
             CommandSet::List(_) => Self::List(ListContext::from(opts)),
             CommandSet::Enter(_) => Self::Enter(EnterContext::from(opts)),
-            _ => todo!(),
+            CommandSet::UseGitBinOnRepo(_) => Self::UseGitBinOnRepo(UseGitBinOnRepoContext::from(opts)),
         };
 
         ctx

--- a/src/context.rs
+++ b/src/context.rs
@@ -15,6 +15,7 @@ pub mod pull;
 pub mod init;
 pub mod clone;
 pub mod delete;
+pub mod rename;
 
 use crate::cli::{CommandSet, RicerCli};
 use commit::CommitContext;
@@ -23,6 +24,7 @@ use pull::PullContext;
 use init::InitContext;
 use clone::CloneContext;
 use delete::DeleteContext;
+use rename::RenameContext;
 
 /// Context states for each Ricer command.
 #[derive(Debug)]
@@ -33,6 +35,7 @@ pub enum Context {
     Init(InitContext),
     Clone(CloneContext),
     Delete(DeleteContext),
+    Rename(RenameContext),
 }
 
 impl From<RicerCli> for Context {
@@ -44,6 +47,7 @@ impl From<RicerCli> for Context {
             CommandSet::Init(_) => Self::Init(InitContext::from(opts)),
             CommandSet::Clone(_) => Self::Clone(CloneContext::from(opts)),
             CommandSet::Delete(_) => Self::Delete(DeleteContext::from(opts)),
+            CommandSet::Rename(_) => Self::Rename(RenameContext::from(opts)),
             _ => todo!(),
         };
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -18,6 +18,7 @@ pub mod delete;
 pub mod rename;
 pub mod status;
 pub mod list;
+pub mod enter;
 
 use crate::cli::{CommandSet, RicerCli};
 use commit::CommitContext;
@@ -29,6 +30,7 @@ use delete::DeleteContext;
 use rename::RenameContext;
 use status::StatusContext;
 use list::ListContext;
+use enter::EnterContext;
 
 /// Context states for each Ricer command.
 #[derive(Debug)]
@@ -42,6 +44,7 @@ pub enum Context {
     Rename(RenameContext),
     Status(StatusContext),
     List(ListContext),
+    Enter(EnterContext),
 }
 
 impl From<RicerCli> for Context {
@@ -56,6 +59,7 @@ impl From<RicerCli> for Context {
             CommandSet::Rename(_) => Self::Rename(RenameContext::from(opts)),
             CommandSet::Status(_) => Self::Status(StatusContext::from(opts)),
             CommandSet::List(_) => Self::List(ListContext::from(opts)),
+            CommandSet::Enter(_) => Self::Enter(EnterContext::from(opts)),
             _ => todo!(),
         };
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -9,30 +9,30 @@
 //! command set allowing for free modifications to Ricer's CLI without the need
 //! to modify the existing internal interface for the command set.
 
-pub mod commit;
-pub mod push;
-pub mod pull;
-pub mod init;
 pub mod clone;
+pub mod commit;
 pub mod delete;
-pub mod rename;
-pub mod status;
-pub mod list;
 pub mod enter;
 pub mod git_on_repo;
+pub mod init;
+pub mod list;
+pub mod pull;
+pub mod push;
+pub mod rename;
+pub mod status;
 
 use crate::cli::{CommandSet, RicerCli};
-use commit::CommitContext;
-use push::PushContext;
-use pull::PullContext;
-use init::InitContext;
 use clone::CloneContext;
+use commit::CommitContext;
 use delete::DeleteContext;
-use rename::RenameContext;
-use status::StatusContext;
-use list::ListContext;
 use enter::EnterContext;
 use git_on_repo::UseGitBinOnRepoContext;
+use init::InitContext;
+use list::ListContext;
+use pull::PullContext;
+use push::PushContext;
+use rename::RenameContext;
+use status::StatusContext;
 
 /// Context states for each Ricer command.
 #[derive(Debug)]
@@ -52,7 +52,7 @@ pub enum Context {
 
 impl From<RicerCli> for Context {
     fn from(opts: RicerCli) -> Self {
-        let ctx = match opts.cmd_set {
+        match opts.cmd_set {
             CommandSet::Commit(_) => Self::Commit(CommitContext::from(opts)),
             CommandSet::Push(_) => Self::Push(PushContext::from(opts)),
             CommandSet::Pull(_) => Self::Pull(PullContext::from(opts)),
@@ -63,9 +63,9 @@ impl From<RicerCli> for Context {
             CommandSet::Status(_) => Self::Status(StatusContext::from(opts)),
             CommandSet::List(_) => Self::List(ListContext::from(opts)),
             CommandSet::Enter(_) => Self::Enter(EnterContext::from(opts)),
-            CommandSet::UseGitBinOnRepo(_) => Self::UseGitBinOnRepo(UseGitBinOnRepoContext::from(opts)),
-        };
-
-        ctx
+            CommandSet::UseGitBinOnRepo(_) => {
+                Self::UseGitBinOnRepo(UseGitBinOnRepoContext::from(opts))
+            }
+        }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,11 +3,25 @@
 
 //! Command context state layer.
 //!
-//! A simple layer of abstraction that flattens the [`RicerCli`] structure into
-//! individual structures that house the required context state for a given
-//! Ricer command. The main overall goal is to decouple Ricer's CLI from the
-//! command set allowing for free modifications to Ricer's CLI without the need
-//! to modify the existing internal interface for the command set.
+//! A _context_ in Ricer, is a definitive and flattened set of options required
+//! for a Ricer command to function.
+//!
+//! The various `[...]Opts` structures contained in [`RicerCli`] provide an
+//! interface for the user. These structures provide a tree structure that can
+//! be annoying to use internally for Ricer. Thus, the context layer converts
+//! the various options offered by [`RicerCli`] into a flattened structure with
+//! at most one level of indirection.
+//!
+//! Another benefit of the context layer, is the decoupling of Ricer commands
+//! from the CLI. Thus, we can make modifications to the CLI freely without
+//! worring about affecting any of the command set implementations.
+//!
+//! # Thanks
+//!
+//! The idea for a context layer came for the cargo-msrv project. See
+//! <https://github.com/foresterre/cargo-msrv/blob/main/src/context.rs#L39C1-L56C10>.
+//!
+//! [`RicerCli`]: crate::cli::RicerCli
 
 pub mod clone;
 pub mod commit;

--- a/src/context.rs
+++ b/src/context.rs
@@ -35,7 +35,8 @@ pub mod push;
 pub mod rename;
 pub mod status;
 
-use crate::cli::{CommandSet, RicerCli};
+use crate::cli::{CommandSet, SharedOpts, RicerCli};
+use clap::ValueEnum;
 use clone::CloneContext;
 use commit::CommitContext;
 use delete::DeleteContext;
@@ -80,4 +81,38 @@ impl From<RicerCli> for Context {
             CommandSet::RepoGit(_) => Self::RepoGit(RepoGitContext::from(opts))
         }
     }
+}
+
+/// Context that is shared across all command contexts.
+#[derive(Debug)]
+pub struct SharedContext {
+    /// Hook execution action choice.
+    pub hook_action: HookAction,
+}
+
+impl From<SharedOpts> for SharedContext {
+    fn from(opts: SharedOpts) -> Self {
+        Self { hook_action: opts.run_hook }
+    }
+}
+
+/// Hook execution options.
+///
+/// Hooks pose as a potential security risk to a user. The user is expected to
+/// know what __any__ hook is doing _before_ executing it, because Ricer does
+/// not provide any way to verify if it is safe to run. However, Ricer does try
+/// to help by offering options in executing a hook. The default behavior is to
+/// show the user the contents of a given hook and prompt them about executing
+/// it. Otherwise, they can choose never to run a hook or always execute a hook
+/// with no prompting.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub enum HookAction {
+    /// Run the hook no questions asked.
+    Always,
+
+    /// Show the user the contents of the hook and prompt them to execute it.
+    Prompt,
+
+    /// Do not execute the hook.
+    Never,
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
+
+//! Command context state layer.
+//!
+//! A simple layer of abstraction that flattens the [`RicerCli`] structure into
+//! individual structures that house the required context state for a given
+//! Ricer command. The main overall goal is to decouple Ricer's CLI from the
+//! command set allowing for free modifications to Ricer's CLI without the need
+//! to modify the existing internal interface for the command set.
+
+use crate::cli::{CommandSet, RicerCli};
+
+/// Context states for each Ricer command.
+#[derive(Debug)]
+pub enum Context {
+}
+
+impl From<RicerCli> for Context {
+    fn from(opts: RicerCli) -> Self {
+        let ctx = match opts.cmd_set {
+            _ => todo!(),
+        };
+
+        ctx
+    }
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -13,12 +13,14 @@ pub mod commit;
 pub mod push;
 pub mod pull;
 pub mod init;
+pub mod clone;
 
 use crate::cli::{CommandSet, RicerCli};
 use commit::CommitContext;
 use push::PushContext;
 use pull::PullContext;
 use init::InitContext;
+use clone::CloneContext;
 
 /// Context states for each Ricer command.
 #[derive(Debug)]
@@ -27,6 +29,7 @@ pub enum Context {
     Push(PushContext),
     Pull(PullContext),
     Init(InitContext),
+    Clone(CloneContext),
 }
 
 impl From<RicerCli> for Context {
@@ -36,6 +39,7 @@ impl From<RicerCli> for Context {
             CommandSet::Push(_) => Self::Push(PushContext::from(opts)),
             CommandSet::Pull(_) => Self::Pull(PullContext::from(opts)),
             CommandSet::Init(_) => Self::Init(InitContext::from(opts)),
+            CommandSet::Clone(_) => Self::Clone(CloneContext::from(opts)),
             _ => todo!(),
         };
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -16,6 +16,7 @@ pub mod init;
 pub mod clone;
 pub mod delete;
 pub mod rename;
+pub mod status;
 
 use crate::cli::{CommandSet, RicerCli};
 use commit::CommitContext;
@@ -25,6 +26,7 @@ use init::InitContext;
 use clone::CloneContext;
 use delete::DeleteContext;
 use rename::RenameContext;
+use status::StatusContext;
 
 /// Context states for each Ricer command.
 #[derive(Debug)]
@@ -36,6 +38,7 @@ pub enum Context {
     Clone(CloneContext),
     Delete(DeleteContext),
     Rename(RenameContext),
+    Status(StatusContext),
 }
 
 impl From<RicerCli> for Context {
@@ -48,6 +51,7 @@ impl From<RicerCli> for Context {
             CommandSet::Clone(_) => Self::Clone(CloneContext::from(opts)),
             CommandSet::Delete(_) => Self::Delete(DeleteContext::from(opts)),
             CommandSet::Rename(_) => Self::Rename(RenameContext::from(opts)),
+            CommandSet::Status(_) => Self::Status(StatusContext::from(opts)),
             _ => todo!(),
         };
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -13,7 +13,7 @@ pub mod clone;
 pub mod commit;
 pub mod delete;
 pub mod enter;
-pub mod git_on_repo;
+pub mod repo_git;
 pub mod init;
 pub mod list;
 pub mod pull;
@@ -26,7 +26,7 @@ use clone::CloneContext;
 use commit::CommitContext;
 use delete::DeleteContext;
 use enter::EnterContext;
-use git_on_repo::UseGitBinOnRepoContext;
+use repo_git::RepoGitContext;
 use init::InitContext;
 use list::ListContext;
 use pull::PullContext;
@@ -47,7 +47,7 @@ pub enum Context {
     Status(StatusContext),
     List(ListContext),
     Enter(EnterContext),
-    UseGitBinOnRepo(UseGitBinOnRepoContext),
+    RepoGit(RepoGitContext),
 }
 
 impl From<RicerCli> for Context {
@@ -63,9 +63,7 @@ impl From<RicerCli> for Context {
             CommandSet::Status(_) => Self::Status(StatusContext::from(opts)),
             CommandSet::List(_) => Self::List(ListContext::from(opts)),
             CommandSet::Enter(_) => Self::Enter(EnterContext::from(opts)),
-            CommandSet::UseGitBinOnRepo(_) => {
-                Self::UseGitBinOnRepo(UseGitBinOnRepoContext::from(opts))
-            }
+            CommandSet::RepoGit(_) => Self::RepoGit(RepoGitContext::from(opts))
         }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -9,22 +9,25 @@
 //! command set allowing for free modifications to Ricer's CLI without the need
 //! to modify the existing internal interface for the command set.
 
-/// Context state for commit command.
 pub mod commit;
+pub mod push;
 
 use crate::cli::{CommandSet, RicerCli};
 use commit::CommitContext;
+use push::PushContext;
 
 /// Context states for each Ricer command.
 #[derive(Debug)]
 pub enum Context {
     Commit(CommitContext),
+    Push(PushContext),
 }
 
 impl From<RicerCli> for Context {
     fn from(opts: RicerCli) -> Self {
         let ctx = match opts.cmd_set {
             CommandSet::Commit(_) => Self::Commit(CommitContext::from(opts)),
+            CommandSet::Push(_) => Self::Push(PushContext::from(opts)),
             _ => todo!(),
         };
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -11,16 +11,19 @@
 
 pub mod commit;
 pub mod push;
+pub mod pull;
 
 use crate::cli::{CommandSet, RicerCli};
 use commit::CommitContext;
 use push::PushContext;
+use pull::PullContext;
 
 /// Context states for each Ricer command.
 #[derive(Debug)]
 pub enum Context {
     Commit(CommitContext),
     Push(PushContext),
+    Pull(PullContext),
 }
 
 impl From<RicerCli> for Context {
@@ -28,6 +31,7 @@ impl From<RicerCli> for Context {
         let ctx = match opts.cmd_set {
             CommandSet::Commit(_) => Self::Commit(CommitContext::from(opts)),
             CommandSet::Push(_) => Self::Push(PushContext::from(opts)),
+            CommandSet::Pull(_) => Self::Pull(PullContext::from(opts)),
             _ => todo!(),
         };
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -14,6 +14,7 @@ pub mod push;
 pub mod pull;
 pub mod init;
 pub mod clone;
+pub mod delete;
 
 use crate::cli::{CommandSet, RicerCli};
 use commit::CommitContext;
@@ -21,6 +22,7 @@ use push::PushContext;
 use pull::PullContext;
 use init::InitContext;
 use clone::CloneContext;
+use delete::DeleteContext;
 
 /// Context states for each Ricer command.
 #[derive(Debug)]
@@ -30,6 +32,7 @@ pub enum Context {
     Pull(PullContext),
     Init(InitContext),
     Clone(CloneContext),
+    Delete(DeleteContext),
 }
 
 impl From<RicerCli> for Context {
@@ -40,6 +43,7 @@ impl From<RicerCli> for Context {
             CommandSet::Pull(_) => Self::Pull(PullContext::from(opts)),
             CommandSet::Init(_) => Self::Init(InitContext::from(opts)),
             CommandSet::Clone(_) => Self::Clone(CloneContext::from(opts)),
+            CommandSet::Delete(_) => Self::Delete(DeleteContext::from(opts)),
             _ => todo!(),
         };
 

--- a/src/context/clone.rs
+++ b/src/context/clone.rs
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
+
+use crate::cli::{CommandSet, RicerCli, RunHookOpts};
+
+/// Context for clone command.
+#[derive(Debug)]
+pub struct CloneContext {
+    /// Remote to clone from.
+    pub remote: String,
+
+    /// Set name of cloned repository.
+    pub repo: Option<String>,
+
+    /// Clone from a branch.
+    pub branch: Option<String>,
+
+    /// Action to take when executing a hook specific to this command.
+    pub run_cmd_hook: RunHookOpts,
+
+    /// Action to take when executing a repository hook.
+    pub run_repo_hook: RunHookOpts,
+}
+
+impl From<RicerCli> for CloneContext {
+    fn from(opts: RicerCli) -> Self {
+        let RicerCli { cmd_opts, cmd_set, ..} = opts;
+        let cmd_set = match cmd_set {
+            CommandSet::Clone(opts) => opts,
+            _ => unreachable!("This should never happen. The command is not 'init'!"),
+        };
+
+        Self {
+            remote: cmd_set.remote,
+            repo: cmd_set.repo,
+            branch: cmd_set.branch,
+            run_cmd_hook: cmd_opts.run_cmd_hook,
+            run_repo_hook: cmd_opts.run_repo_hook,
+        }
+    }
+}

--- a/src/context/clone.rs
+++ b/src/context/clone.rs
@@ -24,7 +24,7 @@ pub struct CloneContext {
 
 impl From<RicerCli> for CloneContext {
     fn from(opts: RicerCli) -> Self {
-        let RicerCli { cmd_opts, cmd_set, ..} = opts;
+        let RicerCli { cmd_opts, cmd_set, .. } = opts;
         let cmd_set = match cmd_set {
             CommandSet::Clone(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'init'!"),

--- a/src/context/clone.rs
+++ b/src/context/clone.rs
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
 
-use crate::cli::{CommandSet, RicerCli, RunHookOpts};
+use crate::cli::{CommandSet, RicerCli};
+use crate::context::SharedContext;
 
 /// Context for clone command.
 #[derive(Debug)]
@@ -15,16 +16,13 @@ pub struct CloneContext {
     /// Clone from a branch.
     pub branch: Option<String>,
 
-    /// Action to take when executing a hook specific to this command.
-    pub run_cmd_hook: RunHookOpts,
-
-    /// Action to take when executing a repository hook.
-    pub run_repo_hook: RunHookOpts,
+    /// Shared features.
+    pub shared: SharedContext,
 }
 
 impl From<RicerCli> for CloneContext {
     fn from(opts: RicerCli) -> Self {
-        let RicerCli { cmd_opts, cmd_set, .. } = opts;
+        let RicerCli { shared_opts, cmd_set, .. } = opts;
         let cmd_set = match cmd_set {
             CommandSet::Clone(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'init'!"),
@@ -34,8 +32,7 @@ impl From<RicerCli> for CloneContext {
             remote: cmd_set.remote,
             repo: cmd_set.repo,
             branch: cmd_set.branch,
-            run_cmd_hook: cmd_opts.run_cmd_hook,
-            run_repo_hook: cmd_opts.run_repo_hook,
+            shared: shared_opts.into(),
         }
     }
 }

--- a/src/context/commit.rs
+++ b/src/context/commit.rs
@@ -1,69 +1,47 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
 
-use crate::cli::{CommandSet, FixupOpts, RicerCli, RunHookOpts};
+use crate::cli::{CommandSet, RicerCli};
+use crate::context::SharedContext;
+use clap::ValueEnum;
 
 /// Context state for commit command.
-///
-/// # Preconditions
-///
-/// 1. The [`amend`] and [`reword`] flags cannot both be true.
-///
-/// > __NOTE__: Precondition 1 will always hold true, because the structure of
-/// > [`RicerCli`] makes it impossible for the user to set both [`amend`] and
-/// > [`reword`] at the same time.
-/// >
-/// > This precondition exists as a reminder in case [`RicerCli`] is somehow
-/// > altered to allow this precondition to be violated by the user. In which
-/// > case runtime checks __will__ need to be added for this.
-///
-/// [`RicerCli`]: crate::cli::RicerCli
-/// [`amend`]: #member.amend
-/// [`reword`]: #member.reword
 #[derive(Debug)]
 pub struct CommitContext {
-    /// Amend changes of current commit. Any changes to index will be added to
-    /// the commit.
-    pub amend: bool,
-
-    /// Reword current commit. Automatically opens user's text editor to edit
-    /// the commit. No changes to index will be added to the commit.
-    pub reword: bool,
+    /// Amend or reword current commit.
+    pub fixup: Option<FixupAction>,
 
     /// Use a string as commit rather than opening up the user's text editor.
     pub message: Option<String>,
 
-    /// Action to take when executing a hook specific to this command.
-    pub run_cmd_hook: RunHookOpts,
-
-    /// Action to take when executing a repository hook.
-    pub run_repo_hook: RunHookOpts,
+    /// Shared features.
+    pub shared: SharedContext,
 }
 
 impl From<RicerCli> for CommitContext {
     fn from(opts: RicerCli) -> Self {
-        let RicerCli { cmd_opts, cmd_set, .. } = opts;
-
+        let RicerCli { shared_opts, cmd_set, .. } = opts;
         let cmd_set = match cmd_set {
             CommandSet::Commit(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'commit'!"),
         };
 
-        let (amend, reword) = match cmd_set.fixup {
-            Some(FixupOpts::Amend) => (true, false),
-            Some(FixupOpts::Reword) => (false, true),
-            None => (false, false),
-        };
-
-        // Literally impossible, but paranoia is a hell of a drug...
-        debug_assert!(!(amend && reword), "Members 'amend' and 'reword' cannot both be true");
-
         Self {
-            amend,
-            reword,
+            fixup: cmd_set.fixup,
             message: cmd_set.message,
-            run_cmd_hook: cmd_opts.run_cmd_hook,
-            run_repo_hook: cmd_opts.run_repo_hook,
+            shared: shared_opts.into(),
         }
     }
+}
+
+/// Fixup options for commit command.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub enum FixupAction {
+    /// Amend changes of current commit. Any changes to index will be added to
+    /// the commit.
+    Amend,
+
+    /// Reword current commit. Automatically opens user's text editor to edit
+    /// the commit. No changes to index will be added to the commit.
+    Reword,
 }

--- a/src/context/commit.rs
+++ b/src/context/commit.rs
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
+
+use crate::cli::{CommandSet, FixupOpts, RicerCli, RunHookOpts};
+
+/// Context state for commit command.
+///
+/// # Preconditions
+///
+/// 1. The [`amend`] and [`reword`] flags cannot both be true.
+///
+/// > __NOTE__: Precondition 1 will always hold true, because the structure of
+/// > [`RicerCli`] makes it impossible for the user to set both [`amend`] and
+/// > [`reword`] at the same time.
+/// >
+/// > This precondition exists as a reminder in case [`RicerCli`] is somehow
+/// > altered to allow this precondition to be violated by the user. In which
+/// > case runtime checks __will__ need to be added for this.
+///
+/// [`RicerCli`]: crate::cli::RicerCli
+/// [`amend`]: #member.amend
+/// [`reword`]: #member.reword
+#[derive(Debug)]
+pub struct CommitContext {
+    /// Amend changes of current commit. Any changes to index will be added to
+    /// the commit.
+    pub amend: bool,
+
+    /// Reword current commit. Automatically opens user's text editor to edit
+    /// the commit. No changes to index will be added to the commit.
+    pub reword: bool,
+
+    /// Use a string as commit rather than opening up the user's text editor.
+    pub message: Option<String>,
+
+    /// Action to take when executing a hook specific to this command.
+    pub run_cmd_hook: RunHookOpts,
+
+    /// Action to take when executing a repository hook.
+    pub run_repo_hook: RunHookOpts,
+}
+
+impl From<RicerCli> for CommitContext {
+    fn from(opts: RicerCli) -> Self {
+        let RicerCli { cmd_opts, cmd_set, .. } = opts;
+
+        let cmd_set = match cmd_set {
+            CommandSet::Commit(opts) => opts,
+            _ => unreachable!("This should never happen. The command is not 'commit'!"),
+        };
+
+        let (amend, reword) = match cmd_set.fixup {
+            Some(FixupOpts::Amend) => (true, false),
+            Some(FixupOpts::Reword) => (false, true),
+            None => (false, false),
+        };
+
+        // Literally impossible, but paranoia is a hell of a drug...
+        debug_assert!(
+            !(amend == true && reword == true),
+            "Members 'amend' and 'reword' cannot both be true"
+        );
+
+        Self {
+            amend,
+            reword,
+            message: cmd_set.message,
+            run_cmd_hook: cmd_opts.run_cmd_hook,
+            run_repo_hook: cmd_opts.run_repo_hook,
+        }
+    }
+}

--- a/src/context/commit.rs
+++ b/src/context/commit.rs
@@ -26,11 +26,7 @@ impl From<RicerCli> for CommitContext {
             _ => unreachable!("This should never happen. The command is not 'commit'!"),
         };
 
-        Self {
-            fixup: cmd_set.fixup,
-            message: cmd_set.message,
-            shared: shared_opts.into(),
-        }
+        Self { fixup: cmd_set.fixup, message: cmd_set.message, shared: shared_opts.into() }
     }
 }
 

--- a/src/context/commit.rs
+++ b/src/context/commit.rs
@@ -56,10 +56,7 @@ impl From<RicerCli> for CommitContext {
         };
 
         // Literally impossible, but paranoia is a hell of a drug...
-        debug_assert!(
-            !(amend == true && reword == true),
-            "Members 'amend' and 'reword' cannot both be true"
-        );
+        debug_assert!(!(amend && reword), "Members 'amend' and 'reword' cannot both be true");
 
         Self {
             amend,

--- a/src/context/delete.rs
+++ b/src/context/delete.rs
@@ -18,7 +18,7 @@ pub struct DeleteContext {
 
 impl From<RicerCli> for DeleteContext {
     fn from(opts: RicerCli) -> Self {
-        let RicerCli { cmd_opts, cmd_set, ..} = opts;
+        let RicerCli { cmd_opts, cmd_set, .. } = opts;
         let cmd_set = match cmd_set {
             CommandSet::Delete(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'delete'!"),

--- a/src/context/delete.rs
+++ b/src/context/delete.rs
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
 
-use crate::cli::{CommandSet, RicerCli, RunHookOpts};
+use crate::cli::{CommandSet, RicerCli};
+use crate::context::SharedContext;
 
 /// Options for delete command.
 #[derive(Debug)]
@@ -9,16 +10,13 @@ pub struct DeleteContext {
     /// Target repository to delete.
     pub repo: String,
 
-    /// Action to take when executing a hook specific to this command.
-    pub run_cmd_hook: RunHookOpts,
-
-    /// Action to take when executing a repository hook.
-    pub run_repo_hook: RunHookOpts,
+    /// Shared features.
+    pub shared: SharedContext,
 }
 
 impl From<RicerCli> for DeleteContext {
     fn from(opts: RicerCli) -> Self {
-        let RicerCli { cmd_opts, cmd_set, .. } = opts;
+        let RicerCli { shared_opts, cmd_set, .. } = opts;
         let cmd_set = match cmd_set {
             CommandSet::Delete(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'delete'!"),
@@ -26,8 +24,7 @@ impl From<RicerCli> for DeleteContext {
 
         Self {
             repo: cmd_set.repo,
-            run_cmd_hook: cmd_opts.run_cmd_hook,
-            run_repo_hook: cmd_opts.run_repo_hook,
+            shared: shared_opts.into(),
         }
     }
 }

--- a/src/context/delete.rs
+++ b/src/context/delete.rs
@@ -22,9 +22,6 @@ impl From<RicerCli> for DeleteContext {
             _ => unreachable!("This should never happen. The command is not 'delete'!"),
         };
 
-        Self {
-            repo: cmd_set.repo,
-            shared: shared_opts.into(),
-        }
+        Self { repo: cmd_set.repo, shared: shared_opts.into() }
     }
 }

--- a/src/context/delete.rs
+++ b/src/context/delete.rs
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
+
+use crate::cli::{CommandSet, RicerCli, RunHookOpts};
+
+/// Options for delete command.
+#[derive(Debug)]
+pub struct DeleteContext {
+    /// Target repository to delete.
+    pub repo: String,
+
+    /// Action to take when executing a hook specific to this command.
+    pub run_cmd_hook: RunHookOpts,
+
+    /// Action to take when executing a repository hook.
+    pub run_repo_hook: RunHookOpts,
+}
+
+impl From<RicerCli> for DeleteContext {
+    fn from(opts: RicerCli) -> Self {
+        let RicerCli { cmd_opts, cmd_set, ..} = opts;
+        let cmd_set = match cmd_set {
+            CommandSet::Delete(opts) => opts,
+            _ => unreachable!("This should never happen. The command is not 'delete'!"),
+        };
+
+        Self {
+            repo: cmd_set.repo,
+            run_cmd_hook: cmd_opts.run_cmd_hook,
+            run_repo_hook: cmd_opts.run_repo_hook,
+        }
+    }
+}

--- a/src/context/enter.rs
+++ b/src/context/enter.rs
@@ -18,7 +18,7 @@ pub struct EnterContext {
 
 impl From<RicerCli> for EnterContext {
     fn from(opts: RicerCli) -> Self {
-        let RicerCli {cmd_opts, cmd_set, ..} = opts;
+        let RicerCli { cmd_opts, cmd_set, .. } = opts;
         let cmd_set = match cmd_set {
             CommandSet::Enter(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'enter'!"),

--- a/src/context/enter.rs
+++ b/src/context/enter.rs
@@ -22,9 +22,6 @@ impl From<RicerCli> for EnterContext {
             _ => unreachable!("This should never happen. The command is not 'enter'!"),
         };
 
-        Self {
-            repo: cmd_set.repo,
-            shared: shared_opts.into(),
-        }
+        Self { repo: cmd_set.repo, shared: shared_opts.into() }
     }
 }

--- a/src/context/enter.rs
+++ b/src/context/enter.rs
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
+
+use crate::cli::{CommandSet, RicerCli, RunHookOpts};
+
+/// Context for enter command.
+#[derive(Debug)]
+pub struct EnterContext {
+    /// Target repository to enter.
+    pub repo: String,
+
+    /// Action to take when executing a hook specific to this command.
+    pub run_cmd_hook: RunHookOpts,
+
+    /// Action to take when executing a repository hook.
+    pub run_repo_hook: RunHookOpts,
+}
+
+impl From<RicerCli> for EnterContext {
+    fn from(opts: RicerCli) -> Self {
+        let RicerCli {cmd_opts, cmd_set, ..} = opts;
+        let cmd_set = match cmd_set {
+            CommandSet::Enter(opts) => opts,
+            _ => unreachable!("This should never happen. The command is not 'enter'!"),
+        };
+
+        Self {
+            repo: cmd_set.repo,
+            run_cmd_hook: cmd_opts.run_cmd_hook,
+            run_repo_hook: cmd_opts.run_repo_hook,
+        }
+    }
+}

--- a/src/context/enter.rs
+++ b/src/context/enter.rs
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
 
-use crate::cli::{CommandSet, RicerCli, RunHookOpts};
+use crate::cli::{CommandSet, RicerCli};
+use crate::context::SharedContext;
 
 /// Context for enter command.
 #[derive(Debug)]
@@ -9,16 +10,13 @@ pub struct EnterContext {
     /// Target repository to enter.
     pub repo: String,
 
-    /// Action to take when executing a hook specific to this command.
-    pub run_cmd_hook: RunHookOpts,
-
-    /// Action to take when executing a repository hook.
-    pub run_repo_hook: RunHookOpts,
+    /// Shared features.
+    pub shared: SharedContext,
 }
 
 impl From<RicerCli> for EnterContext {
     fn from(opts: RicerCli) -> Self {
-        let RicerCli { cmd_opts, cmd_set, .. } = opts;
+        let RicerCli { shared_opts, cmd_set, .. } = opts;
         let cmd_set = match cmd_set {
             CommandSet::Enter(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'enter'!"),
@@ -26,8 +24,7 @@ impl From<RicerCli> for EnterContext {
 
         Self {
             repo: cmd_set.repo,
-            run_cmd_hook: cmd_opts.run_cmd_hook,
-            run_repo_hook: cmd_opts.run_repo_hook,
+            shared: shared_opts.into(),
         }
     }
 }

--- a/src/context/git_on_repo.rs
+++ b/src/context/git_on_repo.rs
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
+
+use crate::cli::{CommandSet, RicerCli};
+use std::ffi::OsString;
+
+/// Context for external subcommand shortcut.
+#[derive(Debug)]
+pub struct UseGitBinOnRepoContext {
+    /// Target repository to run Git binary on.
+    pub repo: OsString,
+
+    /// Arguments to pass into Git binary.
+    pub git_args: Vec<OsString>,
+}
+
+impl From<RicerCli> for UseGitBinOnRepoContext {
+    fn from(opts: RicerCli) -> Self {
+        let RicerCli {cmd_set, ..} = opts;
+        let cmd_set = match cmd_set {
+            CommandSet::UseGitBinOnRepo(opts) => opts,
+            _ => unreachable!("This should never happen. The command is not 'enter'!"),
+        };
+
+        Self {
+            repo: cmd_set[0].clone(),
+            git_args: cmd_set[1..].to_vec(),
+        } 
+    }
+}

--- a/src/context/git_on_repo.rs
+++ b/src/context/git_on_repo.rs
@@ -16,15 +16,12 @@ pub struct UseGitBinOnRepoContext {
 
 impl From<RicerCli> for UseGitBinOnRepoContext {
     fn from(opts: RicerCli) -> Self {
-        let RicerCli {cmd_set, ..} = opts;
+        let RicerCli { cmd_set, .. } = opts;
         let cmd_set = match cmd_set {
             CommandSet::UseGitBinOnRepo(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'enter'!"),
         };
 
-        Self {
-            repo: cmd_set[0].clone(),
-            git_args: cmd_set[1..].to_vec(),
-        } 
+        Self { repo: cmd_set[0].clone(), git_args: cmd_set[1..].to_vec() }
     }
 }

--- a/src/context/init.rs
+++ b/src/context/init.rs
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
 
-use crate::cli::{CommandSet, RicerCli, RunHookOpts};
+use crate::cli::{CommandSet, RicerCli};
+use crate::context::SharedContext;
 
 /// Context state for init command.
 #[derive(Debug)]
@@ -15,16 +16,13 @@ pub struct InitContext {
     /// Set initial branch.
     pub initial_branch: Option<String>,
 
-    /// Action to take when executing a hook specific to this command.
-    pub run_cmd_hook: RunHookOpts,
-
-    /// Action to take when executing a repository hook.
-    pub run_repo_hook: RunHookOpts,
+    /// Shared features.
+    pub shared: SharedContext,
 }
 
 impl From<RicerCli> for InitContext {
     fn from(opts: RicerCli) -> Self {
-        let RicerCli { cmd_opts, cmd_set, .. } = opts;
+        let RicerCli { shared_opts, cmd_set, .. } = opts;
         let cmd_set = match cmd_set {
             CommandSet::Init(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'push'!"),
@@ -34,8 +32,7 @@ impl From<RicerCli> for InitContext {
             name: cmd_set.name,
             initial_remote: cmd_set.initial_remote,
             initial_branch: cmd_set.initial_branch,
-            run_cmd_hook: cmd_opts.run_cmd_hook,
-            run_repo_hook: cmd_opts.run_repo_hook,
+            shared: shared_opts.into(),
         }
     }
 }

--- a/src/context/init.rs
+++ b/src/context/init.rs
@@ -24,7 +24,7 @@ pub struct InitContext {
 
 impl From<RicerCli> for InitContext {
     fn from(opts: RicerCli) -> Self {
-        let RicerCli {cmd_opts, cmd_set, ..} = opts;
+        let RicerCli { cmd_opts, cmd_set, .. } = opts;
         let cmd_set = match cmd_set {
             CommandSet::Init(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'push'!"),

--- a/src/context/init.rs
+++ b/src/context/init.rs
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
+
+use crate::cli::{CommandSet, RicerCli, RunHookOpts};
+
+/// Context state for init command.
+#[derive(Debug)]
+pub struct InitContext {
+    /// Name of repository to initialize.
+    pub name: String,
+
+    /// Set initial remote.
+    pub initial_remote: Option<String>,
+
+    /// Set initial branch.
+    pub initial_branch: Option<String>,
+
+    /// Action to take when executing a hook specific to this command.
+    pub run_cmd_hook: RunHookOpts,
+
+    /// Action to take when executing a repository hook.
+    pub run_repo_hook: RunHookOpts,
+}
+
+impl From<RicerCli> for InitContext {
+    fn from(opts: RicerCli) -> Self {
+        let RicerCli {cmd_opts, cmd_set, ..} = opts;
+        let cmd_set = match cmd_set {
+            CommandSet::Init(opts) => opts,
+            _ => unreachable!("This should never happen. The command is not 'push'!"),
+        };
+
+        Self {
+            name: cmd_set.name,
+            initial_remote: cmd_set.initial_remote,
+            initial_branch: cmd_set.initial_branch,
+            run_cmd_hook: cmd_opts.run_cmd_hook,
+            run_repo_hook: cmd_opts.run_repo_hook,
+        }
+    }
+}

--- a/src/context/list.rs
+++ b/src/context/list.rs
@@ -21,7 +21,7 @@ pub struct ListContext {
 
 impl From<RicerCli> for ListContext {
     fn from(opts: RicerCli) -> Self {
-        let RicerCli {cmd_opts, cmd_set, ..} = opts;
+        let RicerCli { cmd_opts, cmd_set, .. } = opts;
         let cmd_set = match cmd_set {
             CommandSet::List(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'list'!"),

--- a/src/context/list.rs
+++ b/src/context/list.rs
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
 
-use crate::cli::{CommandSet, RicerCli, RunHookOpts};
+use crate::cli::{CommandSet, RicerCli};
+use crate::context::SharedContext;
 
 /// Context for list command.
 #[derive(Debug)]
@@ -12,16 +13,13 @@ pub struct ListContext {
     /// Show all untracked files in repositories.
     pub untracked: bool,
 
-    /// Action to take when executing a hook specific to this command.
-    pub run_cmd_hook: RunHookOpts,
-
-    /// Action to take when executing a repository hook.
-    pub run_repo_hook: RunHookOpts,
+    /// Shared features.
+    pub shared: SharedContext,
 }
 
 impl From<RicerCli> for ListContext {
     fn from(opts: RicerCli) -> Self {
-        let RicerCli { cmd_opts, cmd_set, .. } = opts;
+        let RicerCli { shared_opts, cmd_set, .. } = opts;
         let cmd_set = match cmd_set {
             CommandSet::List(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'list'!"),
@@ -30,8 +28,7 @@ impl From<RicerCli> for ListContext {
         Self {
             tracked: cmd_set.tracked,
             untracked: cmd_set.untracked,
-            run_cmd_hook: cmd_opts.run_cmd_hook,
-            run_repo_hook: cmd_opts.run_repo_hook,
+            shared: shared_opts.into(),
         }
     }
 }

--- a/src/context/list.rs
+++ b/src/context/list.rs
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
+
+use crate::cli::{CommandSet, RicerCli, RunHookOpts};
+
+/// Context for list command.
+#[derive(Debug)]
+pub struct ListContext {
+    /// Show all tracked files in repositories.
+    pub tracked: bool,
+
+    /// Show all untracked files in repositories.
+    pub untracked: bool,
+
+    /// Action to take when executing a hook specific to this command.
+    pub run_cmd_hook: RunHookOpts,
+
+    /// Action to take when executing a repository hook.
+    pub run_repo_hook: RunHookOpts,
+}
+
+impl From<RicerCli> for ListContext {
+    fn from(opts: RicerCli) -> Self {
+        let RicerCli {cmd_opts, cmd_set, ..} = opts;
+        let cmd_set = match cmd_set {
+            CommandSet::List(opts) => opts,
+            _ => unreachable!("This should never happen. The command is not 'list'!"),
+        };
+
+        Self {
+            tracked: cmd_set.tracked,
+            untracked: cmd_set.untracked,
+            run_cmd_hook: cmd_opts.run_cmd_hook,
+            run_repo_hook: cmd_opts.run_repo_hook,
+        }
+    }
+}

--- a/src/context/list.rs
+++ b/src/context/list.rs
@@ -25,10 +25,6 @@ impl From<RicerCli> for ListContext {
             _ => unreachable!("This should never happen. The command is not 'list'!"),
         };
 
-        Self {
-            tracked: cmd_set.tracked,
-            untracked: cmd_set.untracked,
-            shared: shared_opts.into(),
-        }
+        Self { tracked: cmd_set.tracked, untracked: cmd_set.untracked, shared: shared_opts.into() }
     }
 }

--- a/src/context/pull.rs
+++ b/src/context/pull.rs
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
 
-use crate::cli::{CommandSet, RicerCli, RunHookOpts};
+use crate::cli::{CommandSet, RicerCli};
+use crate::context::SharedContext;
 
 /// Context state for pull command.
 #[derive(Debug)]
@@ -12,17 +13,13 @@ pub struct PullContext {
     /// Target branch to push too.
     pub branch: Option<String>,
 
-    /// Action to take when executing a hook specific to this command.
-    pub run_cmd_hook: RunHookOpts,
-
-    /// Action to take when executing a repository hook.
-    pub run_repo_hook: RunHookOpts,
+    /// Shared features.
+    pub shared: SharedContext,
 }
 
 impl From<RicerCli> for PullContext {
     fn from(opts: RicerCli) -> Self {
-        let RicerCli { cmd_opts, cmd_set, .. } = opts;
-
+        let RicerCli { shared_opts, cmd_set, .. } = opts;
         let cmd_set = match cmd_set {
             CommandSet::Pull(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'pull'!"),
@@ -31,8 +28,7 @@ impl From<RicerCli> for PullContext {
         Self {
             remote: cmd_set.remote,
             branch: cmd_set.branch,
-            run_cmd_hook: cmd_opts.run_cmd_hook,
-            run_repo_hook: cmd_opts.run_repo_hook,
+            shared: shared_opts.into(),
         }
     }
 }

--- a/src/context/pull.rs
+++ b/src/context/pull.rs
@@ -21,7 +21,7 @@ pub struct PullContext {
 
 impl From<RicerCli> for PullContext {
     fn from(opts: RicerCli) -> Self {
-        let RicerCli {cmd_opts, cmd_set, ..} = opts;
+        let RicerCli { cmd_opts, cmd_set, .. } = opts;
 
         let cmd_set = match cmd_set {
             CommandSet::Pull(opts) => opts,

--- a/src/context/pull.rs
+++ b/src/context/pull.rs
@@ -25,10 +25,6 @@ impl From<RicerCli> for PullContext {
             _ => unreachable!("This should never happen. The command is not 'pull'!"),
         };
 
-        Self {
-            remote: cmd_set.remote,
-            branch: cmd_set.branch,
-            shared: shared_opts.into(),
-        }
+        Self { remote: cmd_set.remote, branch: cmd_set.branch, shared: shared_opts.into() }
     }
 }

--- a/src/context/pull.rs
+++ b/src/context/pull.rs
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
+
+use crate::cli::{CommandSet, RicerCli, RunHookOpts};
+
+/// Context state for pull command.
+#[derive(Debug)]
+pub struct PullContext {
+    /// Target remote to push too.
+    pub remote: Option<String>,
+
+    /// Target branch to push too.
+    pub branch: Option<String>,
+
+    /// Action to take when executing a hook specific to this command.
+    pub run_cmd_hook: RunHookOpts,
+
+    /// Action to take when executing a repository hook.
+    pub run_repo_hook: RunHookOpts,
+}
+
+impl From<RicerCli> for PullContext {
+    fn from(opts: RicerCli) -> Self {
+        let RicerCli {cmd_opts, cmd_set, ..} = opts;
+
+        let cmd_set = match cmd_set {
+            CommandSet::Pull(opts) => opts,
+            _ => unreachable!("This should never happen. The command is not 'pull'!"),
+        };
+
+        Self {
+            remote: cmd_set.remote,
+            branch: cmd_set.branch,
+            run_cmd_hook: cmd_opts.run_cmd_hook,
+            run_repo_hook: cmd_opts.run_repo_hook,
+        }
+    }
+}

--- a/src/context/push.rs
+++ b/src/context/push.rs
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
 
-use crate::cli::{CommandSet, RicerCli, RunHookOpts};
+use crate::cli::{CommandSet, RicerCli};
+use crate::context::SharedContext;
 
 /// Context state for push command.
 #[derive(Debug)]
@@ -12,17 +13,13 @@ pub struct PushContext {
     /// Target branch to push too.
     pub branch: Option<String>,
 
-    /// Action to take when executing a hook specific to this command.
-    pub run_cmd_hook: RunHookOpts,
-
-    /// Action to take when executing a repository hook.
-    pub run_repo_hook: RunHookOpts,
+    /// Shared features.
+    pub shared: SharedContext,
 }
 
 impl From<RicerCli> for PushContext {
     fn from(opts: RicerCli) -> Self {
-        let RicerCli { cmd_opts, cmd_set, .. } = opts;
-
+        let RicerCli { shared_opts, cmd_set, .. } = opts;
         let cmd_set = match cmd_set {
             CommandSet::Push(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'push'!"),
@@ -31,8 +28,7 @@ impl From<RicerCli> for PushContext {
         Self {
             remote: cmd_set.remote,
             branch: cmd_set.branch,
-            run_cmd_hook: cmd_opts.run_cmd_hook,
-            run_repo_hook: cmd_opts.run_repo_hook,
+            shared: shared_opts.into(),
         }
     }
 }

--- a/src/context/push.rs
+++ b/src/context/push.rs
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
+
+use crate::cli::{CommandSet, RicerCli, RunHookOpts};
+
+/// Context state for push command.
+#[derive(Debug)]
+pub struct PushContext {
+    /// Target remote to push too.
+    pub remote: Option<String>,
+
+    /// Target branch to push too.
+    pub branch: Option<String>,
+
+    /// Action to take when executing a hook specific to this command.
+    pub run_cmd_hook: RunHookOpts,
+
+    /// Action to take when executing a repository hook.
+    pub run_repo_hook: RunHookOpts,
+}
+
+impl From<RicerCli> for PushContext {
+    fn from(opts: RicerCli) -> Self {
+        let RicerCli {cmd_opts, cmd_set, ..} = opts;
+
+        let cmd_set = match cmd_set {
+            CommandSet::Push(opts) => opts,
+            _ => unreachable!("This should never happen. The command is not 'push'!"),
+        };
+
+        Self {
+            remote: cmd_set.remote,
+            branch: cmd_set.branch,
+            run_cmd_hook: cmd_opts.run_cmd_hook,
+            run_repo_hook: cmd_opts.run_repo_hook,
+        }
+    }
+}

--- a/src/context/push.rs
+++ b/src/context/push.rs
@@ -25,10 +25,6 @@ impl From<RicerCli> for PushContext {
             _ => unreachable!("This should never happen. The command is not 'push'!"),
         };
 
-        Self {
-            remote: cmd_set.remote,
-            branch: cmd_set.branch,
-            shared: shared_opts.into(),
-        }
+        Self { remote: cmd_set.remote, branch: cmd_set.branch, shared: shared_opts.into() }
     }
 }

--- a/src/context/push.rs
+++ b/src/context/push.rs
@@ -21,7 +21,7 @@ pub struct PushContext {
 
 impl From<RicerCli> for PushContext {
     fn from(opts: RicerCli) -> Self {
-        let RicerCli {cmd_opts, cmd_set, ..} = opts;
+        let RicerCli { cmd_opts, cmd_set, .. } = opts;
 
         let cmd_set = match cmd_set {
             CommandSet::Push(opts) => opts,

--- a/src/context/rename.rs
+++ b/src/context/rename.rs
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
 
-use crate::cli::{CommandSet, RicerCli, RunHookOpts};
+use crate::cli::{CommandSet, RicerCli};
+use crate::context::SharedContext;
 
 /// Options for rename command.
 #[derive(Debug)]
@@ -12,16 +13,13 @@ pub struct RenameContext {
     /// New new to give target repository.
     pub new_name: String,
 
-    /// Action to take when executing a hook specific to this command.
-    pub run_cmd_hook: RunHookOpts,
-
-    /// Action to take when executing a repository hook.
-    pub run_repo_hook: RunHookOpts,
+    /// Shared features.
+    pub shared: SharedContext,
 }
 
 impl From<RicerCli> for RenameContext {
     fn from(opts: RicerCli) -> Self {
-        let RicerCli { cmd_opts, cmd_set, .. } = opts;
+        let RicerCli { shared_opts, cmd_set, .. } = opts;
         let cmd_set = match cmd_set {
             CommandSet::Rename(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'rename'!"),
@@ -30,8 +28,7 @@ impl From<RicerCli> for RenameContext {
         Self {
             old_name: cmd_set.old_name,
             new_name: cmd_set.new_name,
-            run_cmd_hook: cmd_opts.run_cmd_hook,
-            run_repo_hook: cmd_opts.run_repo_hook,
+            shared: shared_opts.into(),
         }
     }
 }

--- a/src/context/rename.rs
+++ b/src/context/rename.rs
@@ -25,10 +25,6 @@ impl From<RicerCli> for RenameContext {
             _ => unreachable!("This should never happen. The command is not 'rename'!"),
         };
 
-        Self {
-            old_name: cmd_set.old_name,
-            new_name: cmd_set.new_name,
-            shared: shared_opts.into(),
-        }
+        Self { old_name: cmd_set.old_name, new_name: cmd_set.new_name, shared: shared_opts.into() }
     }
 }

--- a/src/context/rename.rs
+++ b/src/context/rename.rs
@@ -21,7 +21,7 @@ pub struct RenameContext {
 
 impl From<RicerCli> for RenameContext {
     fn from(opts: RicerCli) -> Self {
-        let RicerCli { cmd_opts, cmd_set, ..} = opts;
+        let RicerCli { cmd_opts, cmd_set, .. } = opts;
         let cmd_set = match cmd_set {
             CommandSet::Rename(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'rename'!"),

--- a/src/context/rename.rs
+++ b/src/context/rename.rs
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
+
+use crate::cli::{CommandSet, RicerCli, RunHookOpts};
+
+/// Options for rename command.
+#[derive(Debug)]
+pub struct RenameContext {
+    /// Target repository to rename.
+    pub old_name: String,
+
+    /// New new to give target repository.
+    pub new_name: String,
+
+    /// Action to take when executing a hook specific to this command.
+    pub run_cmd_hook: RunHookOpts,
+
+    /// Action to take when executing a repository hook.
+    pub run_repo_hook: RunHookOpts,
+}
+
+impl From<RicerCli> for RenameContext {
+    fn from(opts: RicerCli) -> Self {
+        let RicerCli { cmd_opts, cmd_set, ..} = opts;
+        let cmd_set = match cmd_set {
+            CommandSet::Rename(opts) => opts,
+            _ => unreachable!("This should never happen. The command is not 'rename'!"),
+        };
+
+        Self {
+            old_name: cmd_set.old_name,
+            new_name: cmd_set.new_name,
+            run_cmd_hook: cmd_opts.run_cmd_hook,
+            run_repo_hook: cmd_opts.run_repo_hook,
+        }
+    }
+}

--- a/src/context/repo_git.rs
+++ b/src/context/repo_git.rs
@@ -6,7 +6,7 @@ use std::ffi::OsString;
 
 /// Context for external subcommand shortcut.
 #[derive(Debug)]
-pub struct UseGitBinOnRepoContext {
+pub struct RepoGitContext {
     /// Target repository to run Git binary on.
     pub repo: OsString,
 
@@ -14,11 +14,11 @@ pub struct UseGitBinOnRepoContext {
     pub git_args: Vec<OsString>,
 }
 
-impl From<RicerCli> for UseGitBinOnRepoContext {
+impl From<RicerCli> for RepoGitContext {
     fn from(opts: RicerCli) -> Self {
         let RicerCli { cmd_set, .. } = opts;
         let cmd_set = match cmd_set {
-            CommandSet::UseGitBinOnRepo(opts) => opts,
+            CommandSet::RepoGit(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'enter'!"),
         };
 

--- a/src/context/status.rs
+++ b/src/context/status.rs
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
 
-use crate::cli::{CommandSet, RicerCli, RunHookOpts};
+use crate::cli::{CommandSet, RicerCli};
+use crate::context::SharedContext;
 
 /// Context for status command.
 #[derive(Debug)]
@@ -9,16 +10,13 @@ pub struct StatusContext {
     /// Give a short status report.
     pub terse: bool,
 
-    /// Action to take when executing a hook specific to this command.
-    pub run_cmd_hook: RunHookOpts,
-
-    /// Action to take when executing a repository hook.
-    pub run_repo_hook: RunHookOpts,
+    /// Shared features.
+    pub shared: SharedContext,
 }
 
 impl From<RicerCli> for StatusContext {
     fn from(opts: RicerCli) -> Self {
-        let RicerCli { cmd_opts, cmd_set, .. } = opts;
+        let RicerCli { shared_opts, cmd_set, .. } = opts;
         let cmd_set = match cmd_set {
             CommandSet::Status(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'status'!"),
@@ -26,8 +24,7 @@ impl From<RicerCli> for StatusContext {
 
         Self {
             terse: cmd_set.terse,
-            run_cmd_hook: cmd_opts.run_cmd_hook,
-            run_repo_hook: cmd_opts.run_repo_hook,
+            shared: shared_opts.into(),
         }
     }
 }

--- a/src/context/status.rs
+++ b/src/context/status.rs
@@ -22,9 +22,6 @@ impl From<RicerCli> for StatusContext {
             _ => unreachable!("This should never happen. The command is not 'status'!"),
         };
 
-        Self {
-            terse: cmd_set.terse,
-            shared: shared_opts.into(),
-        }
+        Self { terse: cmd_set.terse, shared: shared_opts.into() }
     }
 }

--- a/src/context/status.rs
+++ b/src/context/status.rs
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
+
+use crate::cli::{CommandSet, RicerCli, RunHookOpts};
+
+/// Context for status command.
+#[derive(Debug)]
+pub struct StatusContext {
+    /// Give a short status report.
+    pub terse: bool,
+
+    /// Action to take when executing a hook specific to this command.
+    pub run_cmd_hook: RunHookOpts,
+
+    /// Action to take when executing a repository hook.
+    pub run_repo_hook: RunHookOpts,
+}
+
+impl From<RicerCli> for StatusContext {
+    fn from(opts: RicerCli) -> Self {
+        let RicerCli {cmd_opts, cmd_set, ..} = opts;
+        let cmd_set = match cmd_set {
+            CommandSet::Status(opts) => opts,
+            _ => unreachable!("This should never happen. The command is not 'status'!"),
+        };
+
+        Self {
+            terse: cmd_set.terse,
+            run_cmd_hook: cmd_opts.run_cmd_hook,
+            run_repo_hook: cmd_opts.run_repo_hook,
+        }
+    }
+}

--- a/src/context/status.rs
+++ b/src/context/status.rs
@@ -18,7 +18,7 @@ pub struct StatusContext {
 
 impl From<RicerCli> for StatusContext {
     fn from(opts: RicerCli) -> Self {
-        let RicerCli {cmd_opts, cmd_set, ..} = opts;
+        let RicerCli { cmd_opts, cmd_set, .. } = opts;
         let cmd_set = match cmd_set {
             CommandSet::Status(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'status'!"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,3 +45,5 @@ use shadow_rs::shadow;
 shadow!(build);
 
 pub mod cli;
+
+pub mod context;

--- a/src/ricer.rs
+++ b/src/ricer.rs
@@ -55,7 +55,7 @@ where
         .filter_level(opts.log_opts.log_level_filter())
         .init();
 
-    let ctx = Context::try_from(opts)?;
+    let ctx = Context::from(opts);
     println!("{:?}", ctx);
 
     // TODO: match and execute command in Ricer's command set...

--- a/src/ricer.rs
+++ b/src/ricer.rs
@@ -11,6 +11,7 @@ use log::error;
 use std::ffi::OsString;
 
 use ricer_core::cli::RicerCli;
+use ricer_core::context::Context;
 
 /// Starting point of Ricer binary.
 ///
@@ -53,6 +54,9 @@ where
         .format_timestamp(None)
         .filter_level(opts.log_opts.log_level_filter())
         .init();
+
+    let ctx = Context::try_from(opts)?;
+    println!("{:?}", ctx);
 
     // TODO: match and execute command in Ricer's command set...
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

Implement a layer of abstraction between Ricer's command implementations and CLI called "context". The context layer synthesizes user options into a set of flattened options containing state that a given command needs to function. Context only contains the options a command needs.

## Area of Effect

- Module `ricer_core::context`.

## Tasks

- [x] Setup context for init command.
- [x] Setup context for push command.
- [x] Setup context for pull command.
- [x] Setup context for clone command.
- [x] Setup context for commit command.
- [x] Setup context for delete command.
- [x] Setup context for enter command.
- [x] Setup context for list command
- [x] Setup context for status command.
- [x] Setup context for rename command.
- [x] Setup context for git command shortcut.
