### PR TITLE
Setup `ricer_core::config::Config` to manage Ricer's configuration data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,12 +295,129 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+
+[[package]]
+name = "futures-task"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
+name = "futures-util"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -322,6 +445,18 @@ dependencies = [
  "openssl-sys",
  "url",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "heck"
@@ -366,6 +501,16 @@ checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -467,6 +612,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,6 +675,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,6 +733,15 @@ checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
 dependencies = [
  "diff",
  "yansi",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -631,6 +803,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "ricer"
 version = "0.3.0"
 dependencies = [
@@ -645,11 +823,71 @@ dependencies = [
  "indoc",
  "log",
  "pretty_assertions",
+ "rstest",
  "serde",
  "shadow-rs",
+ "tempfile",
  "thiserror",
  "toml",
 ]
+
+[[package]]
+name = "rstest"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afd55a67069d6e434a95161415f5beeada95a01c7b815508a82dcb0e1593682"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4165dfae59a39dd41d8dec720d3cbfbc71f69744efb480a3920f5d4e0cc6798d"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
@@ -685,6 +923,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -699,6 +946,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -782,6 +1041,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+
+[[package]]
+name = "toml_edit"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -1035,6 +1311,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "yansi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,7 +810,7 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "ricer"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/rice-configs/ricer"
 authors = ["Jason Pena <jasonpena@awkless.com>"]
 edition = "2021"
 license = "GPL-2.0-or-later WITH GPL-CC-1.0"
-version = "0.3.0"
+version = "0.4.0"
 rust-version = "1.74.1"
 build = "build.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,5 @@ shadow-rs = "0.29"
 [dev-dependencies]
 assert_cmd = "2.0"
 pretty_assertions = "1.4"
+tempfile = "3.10"
+rstest = "0.21"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
+
+//! Configuration data management.
+//!
+//! This module is responsible for providing an interface for managing Ricer's
+//! configuration data.
+//!
+//! Ricer uses `$XDG_CONFIG_HOME/ricer` to house all of its configuration
+//! information. The following represents the overall structure of this
+//! directory:
+//!
+//! ```markdown
+//! $XDG_CONFIG_HOME/ricer/
+//! |-- hooks/
+//! |   |-- hook_script1.sh
+//! |   |-- hook_script2.sh
+//! |   `-- hook_scriptn.sh
+//! |-- repos/
+//! |   |-- config1.git/
+//! |   |-- config2.git/
+//! |   `-- confign.git/
+//! |-- ignores/
+//! |   |-- config1.ignore
+//! |   |-- config2.ignore
+//! |   `-- confign.ignore
+//! `-- config.toml
+//! ```
+//!
+//! The `config.toml` file is the main configuration file for Ricer. The user
+//! can directly modify this configuration file through their preferred text
+//! editor. However, the user can indirectly modify `config.toml` through
+//! Ricer's command set, e.g., init and clone.
+//!
+//! The `hooks/` directory contains all scripts that the user can use as hooks
+//! for Ricer's command set. Ricer _will_ only execute hooks stored in this
+//! directory. Thus, the user can refer to hook scripts by name without the need
+//! to provide an absolute or relative path, because Ricer will automatically
+//! look in the `hooks/` directory for any hook scripts the user wants.
+//!
+//! > __NOTE:__ The limiting of hook scripts to the `hook/` directory is done
+//! > as a very basic security measure. The hope is that the user can easily
+//! > identify potentially dangerious hook scripts by centeralizing all scripts
+//! > in one easily accessible location.
+//!
+//! The `repos/` directory contains all the cloned and initialized repositories
+//! the user wants Ricer to keep track of. This directory is where Ricer finds
+//! and modifies repository information the user passes in through the CLI.
+//!
+//! Finally, the `ignores/` directory houses exclude/ignore files that ensure
+//! that each repository in `repos/` only tracks the portions of the user's
+//! home directory that they are responsible for. This ensures that no
+//! repository the user is tracking through Ricer attempts to track their
+//! entire home directory.
+
+use anyhow::anyhow;
+use directories::ProjectDirs;
+use std::path::{PathBuf, Path};
+
+use crate::error::RicerError;
+
+/// Configuration directory representation.
+///
+/// Meant to represent the layout of Ricer's configuration directory. As a trait
+/// we can easily define and modify the directory layout any time without
+/// much hassle.
+///
+/// # Preconditions
+///
+/// 1. Implementors of this trait should only provide _expected_ paths for each
+///    trait method such that path verification should be left to [`Config`].
+///
+/// [`Config`]: crate::config::Config
+pub trait ConfigDir {
+    /// Get location of Ricer's base configuration directory.
+    fn base_dir(&self) -> &Path;
+
+    /// Get location of Ricer's hook script directory.
+    fn hooks_dir(&self) -> &Path;
+
+    /// Get location of Ricer's tracked repositories directory.
+    fn repos_dir(&self) -> &Path;
+
+    /// Get location of Ricer's set of ignore/exclude files directory.
+    fn ignores_dir(&self) -> &Path;
+}
+

--- a/src/config.rs
+++ b/src/config.rs
@@ -85,3 +85,27 @@ pub trait ConfigDir {
     fn ignores_dir(&self) -> &Path;
 }
 
+/// Default configuration directory.
+///
+/// Meant to represent Ricer's default configuration directory in
+/// `$XDG_CONFIG_HOME/ricer`. See [`crate::config`] for more details about the
+/// layout of Ricer's configuration directory.
+///
+/// [`crate::config`]: crate::config
+#[derive(Debug)]
+pub struct DefaultConfigDir {
+    // $XDG_CONFIG_HOME/ricer/
+    base_dir: PathBuf,
+
+    // $XDG_CONFIG_HOME/ricer/hooks/
+    hooks_dir: PathBuf,
+
+    // $XDG_CONFIG_HOME/ricer/repos/
+    repos_dir: PathBuf,
+
+    // $XDG_CONFIG_HOME/ricer/ignores/
+    ignores_dir: PathBuf,
+}
+
+impl DefaultConfigDir {
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -108,4 +108,21 @@ pub struct DefaultConfigDir {
 }
 
 impl DefaultConfigDir {
+    pub fn try_new() -> Result<Self, RicerError> {
+        let dir = match ProjectDirs::from("com", "awkless", "ricer") {
+            Some(dir) => dir,
+            None => {
+                return Err(RicerError::ConfigError(anyhow!(
+                    "Failed to locate default configuration direcotry"
+                )))
+            }
+        };
+
+        let base_dir = dir.config_dir().to_path_buf();
+        let hooks_dir = dir.config_dir().join("hooks/");
+        let repos_dir = dir.config_dir().join("repos/");
+        let ignores_dir = dir.config_dir().join("ignores/");
+
+        Ok(Self { base_dir, hooks_dir, repos_dir, ignores_dir })
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -116,7 +116,7 @@ impl<D: ConfigDir> Config<D> {
     /// # Postconditions
     ///
     /// 1. Provide full path to hook script, or error out if it does not exist.
-    pub fn try_to_find_hook(&self, hook: impl AsRef<str>) -> Result<PathBuf, RicerError> {
+    pub fn try_to_find_hook_script(&self, hook: impl AsRef<str>) -> Result<PathBuf, RicerError> {
         let hook_path = self.dir.hooks_dir().join(hook.as_ref());
         if !hook_path.exists() {
             return Err(RicerError::ConfigError(anyhow!(
@@ -141,7 +141,7 @@ impl<D: ConfigDir> Config<D> {
     /// # Postconditions
     ///
     /// 1. Provide full path to ignore file, or error out if it does not exist.
-    pub fn try_to_find_ignore(&self, repo: impl AsRef<str>) -> Result<PathBuf, RicerError> {
+    pub fn try_to_find_ignore_file(&self, repo: impl AsRef<str>) -> Result<PathBuf, RicerError> {
         let ignore_path = self.dir.ignores_dir().join(format!("{}.ignore", repo.as_ref()).as_str());
         if !ignore_path.exists() {
             return Err(RicerError::ConfigError(anyhow!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -126,3 +126,21 @@ impl DefaultConfigDir {
         Ok(Self { base_dir, hooks_dir, repos_dir, ignores_dir })
     }
 }
+
+impl ConfigDir for DefaultConfigDir {
+    fn base_dir(&self) -> &Path {
+        self.base_dir.as_path()
+    }
+
+    fn hooks_dir(&self) -> &Path {
+        self.hooks_dir.as_path()
+    }
+
+    fn repos_dir(&self) -> &Path {
+        self.repos_dir.as_path()
+    }
+
+    fn ignores_dir(&self) -> &Path {
+        self.ignores_dir.as_path()
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -83,6 +83,26 @@ impl<D: ConfigDir> Config<D> {
     pub fn new(config_dir: D) -> Self {
         Self { dir: config_dir }
     }
+
+    /// Determine if a repository can be found in configuration directory by name.
+    ///
+    /// # Preconditions
+    ///
+    /// 1. Repository must exist in `repos/` directory.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Provide full path to repository, or error out if it does not exist.
+    pub fn try_to_find_repo(&self, repo: impl AsRef<str>) -> Result<PathBuf, RicerError> {
+        let repo_path = self.dir.repos_dir().join(format!("{}.git", repo.as_ref()).as_str());
+        if !repo_path.exists() {
+            return Err(RicerError::ConfigError(
+                anyhow!("Failed to find '{}' repository", repo.as_ref())
+            ));
+        }
+
+        Ok(repo_path)
+    }
 }
 
 /// Configuration directory representation.

--- a/src/config.rs
+++ b/src/config.rs
@@ -94,7 +94,7 @@ impl<D: ConfigDir> Config<D> {
     /// # Postconditions
     ///
     /// 1. Provide full path to repository, or error out if it does not exist.
-    pub fn try_to_find_repo(&self, repo: impl AsRef<str>) -> Result<PathBuf, RicerError> {
+    pub fn try_to_find_git_repo(&self, repo: impl AsRef<str>) -> Result<PathBuf, RicerError> {
         let repo_path = self.dir.repos_dir().join(format!("{}.git", repo.as_ref()).as_str());
         if !repo_path.exists() {
             return Err(RicerError::ConfigError(anyhow!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,7 +65,7 @@ use crate::error::RicerError;
 /// we can easily define and modify the directory layout any time without
 /// much hassle.
 ///
-/// # Preconditions
+/// # Invariants
 ///
 /// 1. Implementors of this trait should only provide _expected_ paths for each
 ///    trait method such that path verification should be left to [`Config`].
@@ -108,6 +108,35 @@ pub struct DefaultConfigDir {
 }
 
 impl DefaultConfigDir {
+    /// Try to create new instance of default configuration directory.
+    ///
+    /// For Linux and macOS:
+    ///
+    /// 1. Use `$HOME` if it is set and not empty.
+    /// 2. If `$HOME` is not set or empty, then function `getpwuid_r` is used to
+    ///    determine home directory of current user.
+    /// 3. If `getpwuid_r` lacks an entry for the current user ID or the
+    ///    home directory field is empty, _then_ error out.
+    ///
+    /// For Windows:
+    ///
+    /// 1. Retrieve user profile folder using `SHGetKnownFolderPath`.
+    /// 2. If this fails, _then_ error out.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Obtain instance of default configuration directory, or an error
+    ///    indicating that the _expected_ path could not be obtained from the
+    ///    user's environment.
+    ///
+    /// # Invariants
+    ///
+    /// 1. Only determine if defualt configuration directory path is reachable
+    ///    in current user environment, _not_ whether it actually __exists__.
+    ///
+    /// # See
+    ///
+    /// - <https://docs.rs/directories/latest/directories/struct.BaseDirs.html#method.new>
     pub fn try_new() -> Result<Self, RicerError> {
         let dir = match ProjectDirs::from("com", "awkless", "ricer") {
             Some(dir) => dir,

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,6 +103,26 @@ impl<D: ConfigDir> Config<D> {
 
         Ok(repo_path)
     }
+
+    /// Determine if a hook script can be found in configuration directory by name.
+    ///
+    /// # Preconditions
+    ///
+    /// 1. Hook script must exist in `hooks/` directory.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Provide full path to hook script, or error out if it does not exist.
+    pub fn try_to_find_hook(&self, hook: impl AsRef<str>) -> Result<PathBuf, RicerError> {
+        let hook_path = self.dir.hooks_dir().join(hook.as_ref());
+        if !hook_path.exists() {
+            return Err(RicerError::ConfigError(
+                anyhow!("Failed to find '{}' hook", hook.as_ref())
+            ));
+        }
+
+        Ok(hook_path)
+    }
 }
 
 /// Configuration directory representation.

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,7 +55,7 @@
 
 use anyhow::anyhow;
 use directories::ProjectDirs;
-use std::path::{PathBuf, Path};
+use std::path::{Path, PathBuf};
 
 use crate::error::RicerError;
 
@@ -97,9 +97,10 @@ impl<D: ConfigDir> Config<D> {
     pub fn try_to_find_repo(&self, repo: impl AsRef<str>) -> Result<PathBuf, RicerError> {
         let repo_path = self.dir.repos_dir().join(format!("{}.git", repo.as_ref()).as_str());
         if !repo_path.exists() {
-            return Err(RicerError::ConfigError(
-                anyhow!("Failed to find '{}' repository", repo.as_ref())
-            ));
+            return Err(RicerError::ConfigError(anyhow!(
+                "Failed to find '{}' repository",
+                repo.as_ref()
+            )));
         }
 
         Ok(repo_path)
@@ -118,9 +119,10 @@ impl<D: ConfigDir> Config<D> {
     pub fn try_to_find_hook(&self, hook: impl AsRef<str>) -> Result<PathBuf, RicerError> {
         let hook_path = self.dir.hooks_dir().join(hook.as_ref());
         if !hook_path.exists() {
-            return Err(RicerError::ConfigError(
-                anyhow!("Failed to find '{}' hook", hook.as_ref())
-            ));
+            return Err(RicerError::ConfigError(anyhow!(
+                "Failed to find '{}' hook",
+                hook.as_ref()
+            )));
         }
 
         Ok(hook_path)
@@ -142,9 +144,10 @@ impl<D: ConfigDir> Config<D> {
     pub fn try_to_find_ignore(&self, repo: impl AsRef<str>) -> Result<PathBuf, RicerError> {
         let ignore_path = self.dir.ignores_dir().join(format!("{}.ignore", repo.as_ref()).as_str());
         if !ignore_path.exists() {
-            return Err(RicerError::ConfigError(
-                anyhow!("Failed to find '{}' ignore/exclude file", repo.as_ref())
-            ));
+            return Err(RicerError::ConfigError(anyhow!(
+                "Failed to find '{}' ignore/exclude file",
+                repo.as_ref()
+            )));
         }
 
         Ok(ignore_path)

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,7 +69,20 @@ pub struct Config<D: ConfigDir> {
 }
 
 impl<D: ConfigDir> Config<D> {
-
+    /// Create new Ricer configuration.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer_core::config::{ConfigDir, DefaultConfigDir, Config};
+    ///
+    /// let config_dir = DefaultConfigDir::try_new()
+    ///     .expect("Failed to locate default configuration directory");
+    /// let config = Config::new(config_dir);
+    /// ```
+    pub fn new(config_dir: D) -> Self {
+        Self { dir: config_dir }
+    }
 }
 
 /// Configuration directory representation.

--- a/src/config.rs
+++ b/src/config.rs
@@ -59,6 +59,19 @@ use std::path::{PathBuf, Path};
 
 use crate::error::RicerError;
 
+/// Ricer configuration manipulation.
+///
+/// Simple API that allows for the manipulation and management of Ricer's
+/// configuration directory data.
+#[derive(Debug)]
+pub struct Config<D: ConfigDir> {
+    dir: D,
+}
+
+impl<D: ConfigDir> Config<D> {
+
+}
+
 /// Configuration directory representation.
 ///
 /// Meant to represent the layout of Ricer's configuration directory. As a trait

--- a/src/config.rs
+++ b/src/config.rs
@@ -84,7 +84,8 @@ impl<D: ConfigDir> Config<D> {
         Self { dir: config_dir }
     }
 
-    /// Determine if a repository can be found in configuration directory by name.
+    /// Determine if a repository can be found in configuration directory by
+    /// name.
     ///
     /// # Preconditions
     ///
@@ -104,7 +105,8 @@ impl<D: ConfigDir> Config<D> {
         Ok(repo_path)
     }
 
-    /// Determine if a hook script can be found in configuration directory by name.
+    /// Determine if a hook script can be found in configuration directory by
+    /// name.
     ///
     /// # Preconditions
     ///
@@ -122,6 +124,30 @@ impl<D: ConfigDir> Config<D> {
         }
 
         Ok(hook_path)
+    }
+
+    /// Determine if a ignore file can be found in configuration directory by
+    /// repository name.
+    ///
+    /// Ignore files in Ricer are repository specific. Hence, why we need to
+    /// search for them by the name of a given repository.
+    ///
+    /// # Preconditions
+    ///
+    /// 1. Ignore file must exist in `hooks/` directory.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Provide full path to ignore file, or error out if it does not exist.
+    pub fn try_to_find_ignore(&self, repo: impl AsRef<str>) -> Result<PathBuf, RicerError> {
+        let ignore_path = self.dir.ignores_dir().join(format!("{}.ignore", repo.as_ref()).as_str());
+        if !ignore_path.exists() {
+            return Err(RicerError::ConfigError(
+                anyhow!("Failed to find '{}' ignore/exclude file", repo.as_ref())
+            ));
+        }
+
+        Ok(ignore_path)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
+
+#[derive(Debug, thiserror::Error)]
+pub enum RicerError {
+    #[error("Failed to interpret configuration data")]
+    ConfigError(#[from] anyhow::Error),
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,12 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
 
+//! Error system.
+//!
+//! This module contains all error types that a given module of the Ricer code
+//! base may produce. Some of these errors are meant to be recoverable, others
+//! are not. It all depends upon the API of a given module.
+
 #[derive(Debug, thiserror::Error)]
 pub enum RicerError {
     #[error("Failed to interpret configuration data")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,3 +49,5 @@ pub mod error;
 pub mod cli;
 
 pub mod context;
+
+pub mod config;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,8 @@
 use shadow_rs::shadow;
 shadow!(build);
 
+pub mod error;
+
 pub mod cli;
 
 pub mod context;

--- a/src/ricer.rs
+++ b/src/ricer.rs
@@ -25,7 +25,7 @@ fn main() {
         match run_ricer(std::env::args_os) {
             Ok(exit_code) => exit_code,
             Err(error) => {
-                error!("{}", error);
+                error!("{:?}", error);
                 ExitCode::Failure
             }
         }

--- a/tests/config/config.rs
+++ b/tests/config/config.rs
@@ -28,20 +28,20 @@ fn ignore_file_fixture() -> FakeConfigDir {
 }
 
 #[rstest]
-fn try_to_find_hook_gives_correct_path(hook_script_fixture: FakeConfigDir) {
+fn try_to_find_hook_script_gives_correct_path(hook_script_fixture: FakeConfigDir) {
     let expect = hook_script_fixture.path_to_hook_script("fake_hook.sh").as_path().to_path_buf();
-    let result = match Config::new(hook_script_fixture).try_to_find_hook("fake_hook.sh") {
+    let result = match Config::new(hook_script_fixture).try_to_find_hook_script("fake_hook.sh") {
         Ok(path) => path,
-        Err(error) => panic!("Expect `try_to_find_hook` to succeed, but got: {}", error),
+        Err(error) => panic!("Expect `try_to_find_hook_script` to succeed, but got: {}", error),
     };
 
     assert_eq!(result, expect);
 }
 
 #[rstest]
-fn try_to_find_hook_no_hook_found(hook_script_fixture: FakeConfigDir) {
-    let result = match Config::new(hook_script_fixture).try_to_find_hook("nonexistant.sh") {
-        Ok(path) => panic!("Expect `try_to_find_hook` to fail, but got: {}", path.display()),
+fn try_to_find_hook_script_no_hook_found(hook_script_fixture: FakeConfigDir) {
+    let result = match Config::new(hook_script_fixture).try_to_find_hook_script("nonexistant.sh") {
+        Ok(path) => panic!("Expect `try_to_find_hook_script` to fail, but got: {}", path.display()),
         Err(error) => error,
     };
 
@@ -70,20 +70,20 @@ fn try_to_find_git_repo_no_repo_found(git_repo_fixture: FakeConfigDir) {
 }
 
 #[rstest]
-fn try_to_find_ignore_gives_correct_path(ignore_file_fixture: FakeConfigDir) {
+fn try_to_find_ignore_file_gives_correct_path(ignore_file_fixture: FakeConfigDir) {
     let expect = ignore_file_fixture.path_to_ignore_file("fake_repo").as_path().to_path_buf();
-    let result = match Config::new(ignore_file_fixture).try_to_find_ignore("fake_repo") {
+    let result = match Config::new(ignore_file_fixture).try_to_find_ignore_file("fake_repo") {
         Ok(path) => path,
-        Err(error) => panic!("Expect `try_to_find_ignore` to succeed, but got: {}", error),
+        Err(error) => panic!("Expect `try_to_find_ignore_file` to succeed, but got: {}", error),
     };
 
     assert_eq!(result, expect);
 }
 
 #[rstest]
-fn try_to_find_ignore_no_ignore_found(ignore_file_fixture: FakeConfigDir) {
-    let result = match Config::new(ignore_file_fixture).try_to_find_ignore("nonexistant") {
-        Ok(path) => panic!("Expect `try_to_find_ignore` to fail, but got: {}", path.display()),
+fn try_to_find_ignore_file_no_ignore_found(ignore_file_fixture: FakeConfigDir) {
+    let result = match Config::new(ignore_file_fixture).try_to_find_ignore_file("nonexistant") {
+        Ok(path) => panic!("Expect `try_to_find_ignore_file` to fail, but got: {}", path.display()),
         Err(error) => error,
     };
 

--- a/tests/config/config.rs
+++ b/tests/config/config.rs
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
+
+use pretty_assertions::assert_eq;
+use rstest::{fixture, rstest};
+
+use ricer_core::config::Config;
+use ricer_core::error::RicerError;
+
+use crate::tools::fakes::FakeConfigDir;
+
+#[fixture]
+fn ignore_file_fixture() -> FakeConfigDir {
+    let config_dir = FakeConfigDir::builder().ignore_file("fake_repo", "/*").build();
+    config_dir
+}
+
+#[rstest]
+fn try_to_find_ignore_gives_correct_path(ignore_file_fixture: FakeConfigDir) {
+    let expect = ignore_file_fixture.find_ignore("fake_repo").as_path().to_path_buf();
+    let result = match Config::new(ignore_file_fixture).try_to_find_ignore("fake_repo") {
+        Ok(path) => path,
+        Err(error) => panic!("Expect `try_to_find_ignore` to succeed, but got: {}", error),
+    };
+
+    assert_eq!(result, expect);
+}
+
+#[rstest]
+fn try_to_find_ignore_no_ignore_found(ignore_file_fixture: FakeConfigDir) {
+    let result = match Config::new(ignore_file_fixture).try_to_find_ignore("nonexistant") {
+        Ok(path) => panic!("Expect `try_to_find_ignore` to fail, but got: {}", path.display()),
+        Err(error) => error,
+    };
+
+    assert!(matches!(result, RicerError::ConfigError(..)));
+}

--- a/tests/config/config.rs
+++ b/tests/config/config.rs
@@ -16,6 +16,12 @@ fn hook_script_fixture() -> FakeConfigDir {
 }
 
 #[fixture]
+fn git_repo_fixture() -> FakeConfigDir {
+    let config_dir = FakeConfigDir::builder().git_repo("fake_repo").build();
+    config_dir
+}
+
+#[fixture]
 fn ignore_file_fixture() -> FakeConfigDir {
     let config_dir = FakeConfigDir::builder().ignore_file("fake_repo", "/*").build();
     config_dir
@@ -36,6 +42,27 @@ fn try_to_find_hook_gives_correct_path(hook_script_fixture: FakeConfigDir) {
 fn try_to_find_hook_no_hook_found(hook_script_fixture: FakeConfigDir) {
     let result = match Config::new(hook_script_fixture).try_to_find_hook("nonexistant.sh") {
         Ok(path) => panic!("Expect `try_to_find_hook` to fail, but got: {}", path.display()),
+        Err(error) => error,
+    };
+
+    assert!(matches!(result, RicerError::ConfigError(..)));
+}
+
+#[rstest]
+fn try_to_find_git_repo(git_repo_fixture: FakeConfigDir) {
+    let expect = git_repo_fixture.path_to_git_repo("fake_repo").as_path().to_path_buf();
+    let result = match Config::new(git_repo_fixture).try_to_find_git_repo("fake_repo") {
+        Ok(path) => path,
+        Err(error) => panic!("Expect `try_to_find_git_repo` to succeed, but got: {}", error),
+    };
+
+    assert_eq!(result, expect);
+}
+
+#[rstest]
+fn try_to_find_git_repo_no_repo_found(git_repo_fixture: FakeConfigDir) {
+    let result = match Config::new(git_repo_fixture).try_to_find_git_repo("nonexistant") {
+        Ok(path) => panic!("Expect `try_to_find_git_repo` to fail, but got: {}", path.display()),
         Err(error) => error,
     };
 

--- a/tests/config/config.rs
+++ b/tests/config/config.rs
@@ -10,9 +10,36 @@ use ricer_core::error::RicerError;
 use crate::tools::fakes::FakeConfigDir;
 
 #[fixture]
+fn hook_script_fixture() -> FakeConfigDir {
+    let config_dir = FakeConfigDir::builder().hook_script("fake_hook.sh", "chmod +x file").build();
+    config_dir
+}
+
+#[fixture]
 fn ignore_file_fixture() -> FakeConfigDir {
     let config_dir = FakeConfigDir::builder().ignore_file("fake_repo", "/*").build();
     config_dir
+}
+
+#[rstest]
+fn try_to_find_hook_gives_correct_path(hook_script_fixture: FakeConfigDir) {
+    let expect = hook_script_fixture.path_to_hook_script("fake_hook.sh").as_path().to_path_buf();
+    let result = match Config::new(hook_script_fixture).try_to_find_hook("fake_hook.sh") {
+        Ok(path) => path,
+        Err(error) => panic!("Expect `try_to_find_hook` to succeed, but got: {}", error),
+    };
+
+    assert_eq!(result, expect);
+}
+
+#[rstest]
+fn try_to_find_hook_no_hook_found(hook_script_fixture: FakeConfigDir) {
+    let result = match Config::new(hook_script_fixture).try_to_find_hook("nonexistant.sh") {
+        Ok(path) => panic!("Expect `try_to_find_hook` to fail, but got: {}", path.display()),
+        Err(error) => error,
+    };
+
+    assert!(matches!(result, RicerError::ConfigError(..)));
 }
 
 #[rstest]

--- a/tests/config/config.rs
+++ b/tests/config/config.rs
@@ -17,7 +17,7 @@ fn ignore_file_fixture() -> FakeConfigDir {
 
 #[rstest]
 fn try_to_find_ignore_gives_correct_path(ignore_file_fixture: FakeConfigDir) {
-    let expect = ignore_file_fixture.find_ignore("fake_repo").as_path().to_path_buf();
+    let expect = ignore_file_fixture.path_to_ignore_file("fake_repo").as_path().to_path_buf();
     let result = match Config::new(ignore_file_fixture).try_to_find_ignore("fake_repo") {
         Ok(path) => path,
         Err(error) => panic!("Expect `try_to_find_ignore` to succeed, but got: {}", error),

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -1,6 +1,4 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
 
-pub mod tools;
-
 mod config;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
+
+pub mod tools;

--- a/tests/tools.rs
+++ b/tests/tools.rs
@@ -58,3 +58,19 @@ impl ConfigDir for FakeConfigDir {
         self.ignores_dir.path()
     }
 }
+
+impl Drop for FakeConfigDir {
+    fn drop(&mut self) {
+        debug!("Remove '{}'", self.ignores_dir.path().display());
+        remove_dir_all(self.ignores_dir.path()).expect("Failed to close 'ignores/' fixture");
+
+        debug!("Remove '{}'", self.repos_dir.path().display());
+        remove_dir_all(self.repos_dir.path()).expect("Failed to close 'repos/' fixture");
+
+        debug!("Remove '{}'", self.hooks_dir.path().display());
+        remove_dir_all(self.hooks_dir.path()).expect("Failed to close 'hooks/' fixture");
+
+        debug!("Remove '{}'", self.base_dir.path().display());
+        remove_dir_all(self.base_dir.path()).expect("Failed to close base directory fixture");
+    }
+}

--- a/tests/tools.rs
+++ b/tests/tools.rs
@@ -40,3 +40,21 @@ impl FakeConfigDir {
         Self { base_dir, hooks_dir, repos_dir, ignores_dir }
     }
 }
+
+impl ConfigDir for FakeConfigDir {
+    fn base_dir(&self) -> &Path {
+        self.base_dir.path()
+    }
+
+    fn hooks_dir(&self) -> &Path {
+        self.hooks_dir.path()
+    }
+
+    fn repos_dir(&self) -> &Path {
+        self.repos_dir.path()
+    }
+
+    fn ignores_dir(&self) -> &Path {
+        self.ignores_dir.path()
+    }
+}

--- a/tests/tools.rs
+++ b/tests/tools.rs
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
+
+use std::path::Path;
+use log::debug;
+use std::fs::remove_dir_all;
+use tempfile::{Builder, TempDir};
+
+use ricer_core::config::ConfigDir;
+
+pub struct FakeConfigDir {
+    base_dir: TempDir,
+    hooks_dir: TempDir,
+    repos_dir: TempDir,
+    ignores_dir: TempDir,
+}
+
+impl FakeConfigDir {
+    // TODO...
+}

--- a/tests/tools.rs
+++ b/tests/tools.rs
@@ -16,5 +16,27 @@ pub struct FakeConfigDir {
 }
 
 impl FakeConfigDir {
-    // TODO...
+    pub fn new() -> Self {
+        let base_dir = Builder::new()
+            .prefix("ricer")
+            .tempdir()
+            .expect("Failed to create base directory");
+
+        let hooks_dir = Builder::new()
+            .prefix("hooks")
+            .tempdir_in(base_dir.path())
+            .expect("Failed to create 'hooks' directory");
+
+        let repos_dir = Builder::new()
+            .prefix("repos")
+            .tempdir_in(base_dir.path())
+            .expect("Failed to create 'repos' directory");
+
+        let ignores_dir = Builder::new()
+            .prefix("ignores")
+            .tempdir_in(base_dir.path())
+            .expect("Failed to create 'ignores' directory");
+
+        Self { base_dir, hooks_dir, repos_dir, ignores_dir }
+    }
 }

--- a/tests/tools/fakes.rs
+++ b/tests/tools/fakes.rs
@@ -50,7 +50,9 @@ impl FakeConfigDir {
     //
     // Ignore files in Ricer are named after repositories in the `repos`
     // directory with a '.ignore' extension. However, not all repositories will
-    // have a corresponding ignore file.
+    // have a corresponding ignore file. Usually, repositories without ignore
+    // files are ones who do not target the user's home directory as their
+    // working tree.
     //
     // Regardless, to get an absolute path to fake ignore file, the caller
     // just needs to provide the name of the file without the `.ignore`
@@ -58,7 +60,7 @@ impl FakeConfigDir {
     //
     // Preconditions:
     //
-    // 1. Ignore file exists in `file_stubs` member.
+    // 1. Ignore file is being tracked by fake configuration directory.
     //
     // Postconditions:
     //
@@ -66,7 +68,8 @@ impl FakeConfigDir {
     //
     // Errors:
     //
-    // Panics if it cannot find fake ignore file.
+    // Panics if ignore file is not being tracked by fake configuration
+    // directory.
     //
     // Examples:
     //
@@ -82,7 +85,44 @@ impl FakeConfigDir {
         let ignore_file = format!("{}.ignore", repo.as_ref().display());
         match self.file_stubs.get(&self.ignores_dir().join(&ignore_file)) {
             Some(file) => file,
-            None => panic!("Failed to find '{}' in 'ignores' directory", &ignore_file),
+            None => panic!("Ignore file '{}' is not being tracked by fake directory", &ignore_file),
+        }
+    }
+
+    // Get path to stored hook script in fake 'hooks' directory. 
+    //
+    // Caller needs to provide full filename of hook to obtain its path.
+    //
+    // Preconditions:
+    //
+    // 1. Hook script must be currently tracked by fake configuration directory.
+    //
+    // Postconditions:
+    //
+    // 1. Get absolute path to hook script in fake 'hooks' directory.
+    //
+    // Errors:
+    //
+    // Panics if named hook script is not being tracked by fake configuration
+    // directory.
+    //
+    // Examples:
+    //
+    // ```
+    // use crate::tools::fakes::FakeConfigDir;
+    //
+    // let config = FakeConfigDir::builder()
+    //     .hook_script("hook.sh", "chmod +x blah")
+    //     .build();
+    // let path = config.path_to_hook_script("hook.sh");
+    // ```
+    pub fn path_to_hook_script(&self, name: impl AsRef<Path>) -> &FileStub {
+        match self.file_stubs.get(&self.hooks_dir().join(name.as_ref())) {
+            Some(file) => file,
+            None => panic!(
+                "Hook script '{}' is not being tracked by fake directory",
+                &name.as_ref().display()
+            ),
         }
     }
 }

--- a/tests/tools/fakes.rs
+++ b/tests/tools/fakes.rs
@@ -10,23 +10,77 @@ use ricer_core::config::ConfigDir;
 
 use crate::tools::stubs::FileStub;
 
+// Create an instance of a fake Ricer configuration directory.
+//
+// Generally used to decorate `ricer_core::config::Config` with basic fixtures
+// for integration testing purposes. This fake configuration directory handler
+// generally tries to maintain the structure of Ricer's configuration directory
+// for API feedback purposes.
 #[derive(Debug)]
 pub struct FakeConfigDir {
+    // Fake 'base' directory that houses all other fake sub-directories.
     base_dir: TempDir,
+
+    // Fake 'hooks' directory.
     hooks_dir: TempDir,
+
+    // Fake 'repos' directory.
     repos_dir: TempDir,
+
+    // Fake 'ignores' directory.
     ignores_dir: TempDir,
-    stub_files: HashMap<PathBuf, FileStub>,
+
+    // Store tracked stub files using their path as the key. HashMap is used for
+    // O(1) lookup.
+    file_stubs: HashMap<PathBuf, FileStub>,
 }
 
 impl FakeConfigDir {
+    // Create an instance of builder to build a new fake configuration directory.
+    //
+    // Postconditions:
+    //
+    // 1. Obtain a valid instance of `FakeConfigDirBuilder` to begin building a
+    //    fake configuration directory.
     pub fn builder() -> FakeConfigDirBuilder {
         FakeConfigDirBuilder::new()
     }
 
-    pub fn find_ignore(&self, repo: impl AsRef<Path>) -> &FileStub {
+    // Get stored path to target fake ignore file in 'ignores' directory.
+    //
+    // Ignore files in Ricer are named after repositories in the `repos`
+    // directory with a '.ignore' extension. However, not all repositories will
+    // have a corresponding ignore file.
+    //
+    // Regardless, to get an absolute path to fake ignore file, the caller
+    // just needs to provide the name of the file without the `.ignore`
+    // extension.
+    //
+    // Preconditions:
+    //
+    // 1. Ignore file exists in `file_stubs` member.
+    //
+    // Postconditions:
+    //
+    // 1. Get absolute path to fake ignore file.
+    //
+    // Errors:
+    //
+    // Panics if it cannot find fake ignore file.
+    //
+    // Examples:
+    //
+    // ```
+    // use crate::tools::fakes::FakeConfigDir;
+    //
+    // let config = FakeConfigDir::builder()
+    //     .ignore_file("fake_ignore", "/*") // Stored as 'fake_ignore.ignore'
+    //     .build();
+    // let path = config.path_to_ignore_file("fake_ignore");
+    // ```
+    pub fn path_to_ignore_file(&self, repo: impl AsRef<Path>) -> &FileStub {
         let ignore_file = format!("{}.ignore", repo.as_ref().display());
-        match self.stub_files.get(&self.ignores_dir().join(&ignore_file)) {
+        match self.file_stubs.get(&self.ignores_dir().join(&ignore_file)) {
             Some(file) => file,
             None => panic!("Failed to find '{}' in 'ignores' directory", &ignore_file),
         }
@@ -53,7 +107,7 @@ impl ConfigDir for FakeConfigDir {
 
 impl Drop for FakeConfigDir {
     fn drop(&mut self) {
-        self.stub_files.clear();
+        self.file_stubs.clear();
         remove_dir_all(self.ignores_dir.path()).expect("Failed to close 'ignores/' fixture");
         remove_dir_all(self.repos_dir.path()).expect("Failed to close 'repos/' fixture");
         remove_dir_all(self.hooks_dir.path()).expect("Failed to close 'hooks/' fixture");
@@ -67,10 +121,39 @@ pub struct FakeConfigDirBuilder {
     hooks_dir: TempDir,
     repos_dir: TempDir,
     ignores_dir: TempDir,
-    stub_files: HashMap<PathBuf, FileStub>,
+    file_stubs: HashMap<PathBuf, FileStub>,
 }
 
 impl FakeConfigDirBuilder {
+    // Construct new instance of fake configuration directory builder.
+    //
+    // Postconditions:
+    //
+    // 1. Get valid instance of fake configuration directory builder.
+    //
+    // Invariants:
+    //
+    // 1. Do not leave any fields uninitialized without a sane default value.
+    //
+    // Errors:
+    //
+    // Panics if it cannot create the directory structure needed to fake Ricer's
+    // configuration directory.
+    //
+    // Note:
+    //
+    // Caller should use `FakeConfigDir::builder()` instead of directly calling
+    // this method. That way they can use `FileStub` more directly. Unless they
+    // need the file stub instance separate from their file stub builder
+    // instance for whatever reason (unlikely but possible).
+    //
+    // Examples:
+    //
+    // ```
+    // use crate::tools::fakes::FakeConfigDirBuilder;
+    //
+    // let builder = FakeConfigDirBuilder::new();
+    // ```
     pub fn new() -> Self {
         let base_dir =
             Builder::new().prefix("ricer").tempdir().expect("Failed to create base directory");
@@ -90,38 +173,92 @@ impl FakeConfigDirBuilder {
             .tempdir_in(base_dir.path())
             .expect("Failed to create 'ignores' directory");
 
-        Self { base_dir, hooks_dir, repos_dir, ignores_dir, stub_files: HashMap::default() }
+        Self { base_dir, hooks_dir, repos_dir, ignores_dir, file_stubs: HashMap::default() }
     }
 
+    // Write fake ignore file in fake 'ignores' directory.
+    //
+    // Postconditions:
+    //
+    // 1. Write a fake ignore file in the fake 'ignores' directory retaining
+    //    file stub data.
+    //
+    // Errors:
+    //
+    // Panics if it cannot create fake ignore file in 'ignores' directory.
+    //
+    // Examples:
+    //
+    // ```
+    // use crate::tools::fakes::FakeConfigDirBuilder;
+    //
+    // let builder = FakeConfigDirBuilder::new()
+    //     .ignore_file("fake_ignore", "/*");
+    // ```
     pub fn ignore_file(mut self, name: impl AsRef<str>, data: impl AsRef<str>) -> Self {
-        let stub_file = FileStub::builder()
+        let file_stub = FileStub::builder()
             .path(self.ignores_dir.path().join(format!("{}.ignore", name.as_ref())))
             .data(data.as_ref())
             .executable(false)
             .build();
 
-        self.stub_files.insert(stub_file.as_path().to_path_buf(), stub_file);
+        self.file_stubs.insert(file_stub.as_path().to_path_buf(), file_stub);
         self
     }
 
+    // Create executable fake hook script in the fake 'hooks' directory.
+    //
+    // Postconditions:
+    //
+    // 1. Create executable hook script in fake 'hooks' directory retaining
+    //    file stub data.
+    //
+    // Errors:
+    //
+    // Panics if it cannot create executable hook script for whatever reason.
+    //
+    // Examples:
+    //
+    // ```
+    // use crate::tools::fakes::FakeConfigDirBuilder;
+    //
+    // let builder = FakeConfigDirBuilder::new()
+    //     .hook_script("fake_hook", "chmod +x somefile.txt");
+    // ```
     pub fn hook_script(mut self, name: impl AsRef<str>, data: impl AsRef<str>) -> Self {
-        let stub_file = FileStub::builder()
+        let file_stub = FileStub::builder()
             .path(self.hooks_dir.path().join(name.as_ref()))
             .data(data.as_ref())
             .executable(true)
             .build();
 
-        self.stub_files.insert(stub_file.as_path().to_path_buf(), stub_file);
+        self.file_stubs.insert(file_stub.as_path().to_path_buf(), file_stub);
         self
     }
 
+    // Build fake configuration directory instance.
+    //
+    // Postconditions:
+    //
+    // 1. Provide `FakeConfigDir` instance with what was built.
+    //
+    // Examples:
+    //
+    // ```
+    // use crate::tools::fakes::FakeConfigDirBuilder;
+    //
+    // let config = FakeConfigDirBuilder::new()
+    //     .hook_script("fake_hook", "chmod +x somefile.txt")
+    //     .ignore_file("fake_ignore", "/*")
+    //     .build();
+    // ```
     pub fn build(self) -> FakeConfigDir {
         FakeConfigDir {
             base_dir: self.base_dir,
             hooks_dir: self.hooks_dir,
             repos_dir: self.repos_dir,
             ignores_dir: self.ignores_dir,
-            stub_files: self.stub_files,
+            file_stubs: self.file_stubs,
         }
     }
 }

--- a/tests/tools/fakes.rs
+++ b/tests/tools/fakes.rs
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
 
-use std::fs::remove_dir_all;
-use std::path::{PathBuf, Path};
-use tempfile::{Builder, TempDir};
 use std::collections::HashMap;
+use std::fs::remove_dir_all;
+use std::path::{Path, PathBuf};
+use tempfile::{Builder, TempDir};
 
 use ricer_core::config::ConfigDir;
 
@@ -24,6 +24,12 @@ impl FakeConfigDir {
         FakeConfigDirBuilder::new()
     }
 
+    pub fn find_ignore(&self, repo: impl AsRef<Path>) -> &FileStub {
+        let ignore_file = format!("{}.ignore", repo.as_ref().display());
+        match self.stub_files.get(&self.ignores_dir().join(&ignore_file)) {
+            Some(file) => file,
+            None => panic!("Failed to find '{}' in 'ignores' directory", &ignore_file),
+        }
     }
 }
 
@@ -110,12 +116,12 @@ impl FakeConfigDirBuilder {
     }
 
     pub fn build(self) -> FakeConfigDir {
-        FakeConfigDir { 
+        FakeConfigDir {
             base_dir: self.base_dir,
             hooks_dir: self.hooks_dir,
             repos_dir: self.repos_dir,
             ignores_dir: self.ignores_dir,
-            stub_files: self.stub_files
+            stub_files: self.stub_files,
         }
     }
 }

--- a/tests/tools/fakes.rs
+++ b/tests/tools/fakes.rs
@@ -8,8 +8,6 @@ use tempfile::{Builder, TempDir};
 
 use ricer_core::config::ConfigDir;
 
-use crate::tools::stubs::StubFile;
-
 pub struct FakeConfigDir {
     base_dir: TempDir,
     hooks_dir: TempDir,
@@ -37,6 +35,10 @@ impl FakeConfigDir {
             .tempdir_in(base_dir.path())
             .expect("Failed to create 'ignores' directory");
 
+        debug!("Fake configuration base directory '{}'", base_dir.path().display());
+        debug!("Fake hooks directory '{}'", hooks_dir.path().display());
+        debug!("Fake repos directory '{}'", repos_dir.path().display());
+        debug!("Fake ignores directory '{}'", ignores_dir.path().display());
         Self { base_dir, hooks_dir, repos_dir, ignores_dir }
     }
 }

--- a/tests/tools/fakes.rs
+++ b/tests/tools/fakes.rs
@@ -8,7 +8,7 @@ use tempfile::{Builder, TempDir};
 
 use ricer_core::config::ConfigDir;
 
-use crate::tools::stubs::FileStub;
+use crate::tools::stubs::{FileStub, GitRepoStub};
 
 // Create an instance of a fake Ricer configuration directory.
 //
@@ -33,6 +33,9 @@ pub struct FakeConfigDir {
     // Store tracked stub files using their path as the key. HashMap is used for
     // O(1) lookup.
     file_stubs: HashMap<PathBuf, FileStub>,
+
+    // Store tracked stub repositories using their path as the key.
+    repo_stubs: HashMap<PathBuf, GitRepoStub>,
 }
 
 impl FakeConfigDir {
@@ -89,7 +92,7 @@ impl FakeConfigDir {
         }
     }
 
-    // Get path to stored hook script in fake 'hooks' directory. 
+    // Get path to stored hook script in fake 'hooks' directory.
     //
     // Caller needs to provide full filename of hook to obtain its path.
     //
@@ -123,6 +126,42 @@ impl FakeConfigDir {
                 "Hook script '{}' is not being tracked by fake directory",
                 &name.as_ref().display()
             ),
+        }
+    }
+
+    // Get path to stored Git repository in fake 'repos' directory.
+    //
+    // Caller needs to provide full filename of hook to obtain its path.
+    //
+    // Preconditions:
+    //
+    // 1. Git repository must be currently tracked by fake configuration
+    //    directory.
+    //
+    // Postconditions:
+    //
+    // 1. Get absolute path to Git repository in fake 'repos' directory.
+    //
+    // Errors:
+    //
+    // Panics if named Git repository is not being tracked by fake configuration
+    // directory.
+    //
+    // Examples:
+    //
+    // ```
+    // use crate::tools::fakes::FakeConfigDir;
+    //
+    // let config = FakeConfigDir::builder()
+    //     .git_repo("fake_repo")
+    //     .build();
+    // let path = config.path_to_hook_script("hook.sh");
+    // ```
+    pub fn path_to_git_repo(&self, name: impl AsRef<Path>) -> &GitRepoStub {
+        let git_repo = format!("{}.git", name.as_ref().display());
+        match self.repo_stubs.get(&self.repos_dir().join(&git_repo)) {
+            Some(repo) => repo,
+            None => panic!("Repository '{}' is not being tracked by fake directory", &git_repo),
         }
     }
 }
@@ -162,6 +201,7 @@ pub struct FakeConfigDirBuilder {
     repos_dir: TempDir,
     ignores_dir: TempDir,
     file_stubs: HashMap<PathBuf, FileStub>,
+    repo_stubs: HashMap<PathBuf, GitRepoStub>,
 }
 
 impl FakeConfigDirBuilder {
@@ -213,7 +253,14 @@ impl FakeConfigDirBuilder {
             .tempdir_in(base_dir.path())
             .expect("Failed to create 'ignores' directory");
 
-        Self { base_dir, hooks_dir, repos_dir, ignores_dir, file_stubs: HashMap::default() }
+        Self {
+            base_dir,
+            hooks_dir,
+            repos_dir,
+            ignores_dir,
+            file_stubs: HashMap::default(),
+            repo_stubs: HashMap::default(),
+        }
     }
 
     // Write fake ignore file in fake 'ignores' directory.
@@ -276,6 +323,31 @@ impl FakeConfigDirBuilder {
         self
     }
 
+    // Create Git repository in 'repos' directory.
+    //
+    // Postconditions:
+    //
+    // 1. Create Git repository in 'repos' directory retaining repo stub data.
+    //
+    // Errors:
+    //
+    // Panics if it cannot create the Git repository.
+    //
+    // Examples:
+    //
+    // ```
+    // use crate::tools::fakes::FakeConfigDirBuilder;
+    //
+    // let builder = FakeConfigDirBuilder::new()
+    //     .git_repo("fake_repo")
+    // ```
+    pub fn git_repo(mut self, name: impl AsRef<str>) -> Self {
+        let repo = format!("{}.git", name.as_ref());
+        let repo_stub = GitRepoStub::new(self.repos_dir.path().join(repo));
+        self.repo_stubs.insert(repo_stub.as_path().to_path_buf(), repo_stub);
+        self
+    }
+
     // Build fake configuration directory instance.
     //
     // Postconditions:
@@ -299,6 +371,7 @@ impl FakeConfigDirBuilder {
             repos_dir: self.repos_dir,
             ignores_dir: self.ignores_dir,
             file_stubs: self.file_stubs,
+            repo_stubs: self.repo_stubs,
         }
     }
 }

--- a/tests/tools/fakes.rs
+++ b/tests/tools/fakes.rs
@@ -1,45 +1,29 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
 
-use log::debug;
 use std::fs::remove_dir_all;
-use std::path::Path;
+use std::path::{PathBuf, Path};
 use tempfile::{Builder, TempDir};
+use std::collections::HashMap;
 
 use ricer_core::config::ConfigDir;
 
+use crate::tools::stubs::FileStub;
+
+#[derive(Debug)]
 pub struct FakeConfigDir {
     base_dir: TempDir,
     hooks_dir: TempDir,
     repos_dir: TempDir,
     ignores_dir: TempDir,
+    stub_files: HashMap<PathBuf, FileStub>,
 }
 
 impl FakeConfigDir {
-    pub fn new() -> Self {
-        let base_dir =
-            Builder::new().prefix("ricer").tempdir().expect("Failed to create base directory");
+    pub fn builder() -> FakeConfigDirBuilder {
+        FakeConfigDirBuilder::new()
+    }
 
-        let hooks_dir = Builder::new()
-            .prefix("hooks")
-            .tempdir_in(base_dir.path())
-            .expect("Failed to create 'hooks' directory");
-
-        let repos_dir = Builder::new()
-            .prefix("repos")
-            .tempdir_in(base_dir.path())
-            .expect("Failed to create 'repos' directory");
-
-        let ignores_dir = Builder::new()
-            .prefix("ignores")
-            .tempdir_in(base_dir.path())
-            .expect("Failed to create 'ignores' directory");
-
-        debug!("Fake configuration base directory '{}'", base_dir.path().display());
-        debug!("Fake hooks directory '{}'", hooks_dir.path().display());
-        debug!("Fake repos directory '{}'", repos_dir.path().display());
-        debug!("Fake ignores directory '{}'", ignores_dir.path().display());
-        Self { base_dir, hooks_dir, repos_dir, ignores_dir }
     }
 }
 
@@ -63,16 +47,75 @@ impl ConfigDir for FakeConfigDir {
 
 impl Drop for FakeConfigDir {
     fn drop(&mut self) {
-        debug!("Remove '{}'", self.ignores_dir.path().display());
+        self.stub_files.clear();
         remove_dir_all(self.ignores_dir.path()).expect("Failed to close 'ignores/' fixture");
-
-        debug!("Remove '{}'", self.repos_dir.path().display());
         remove_dir_all(self.repos_dir.path()).expect("Failed to close 'repos/' fixture");
-
-        debug!("Remove '{}'", self.hooks_dir.path().display());
         remove_dir_all(self.hooks_dir.path()).expect("Failed to close 'hooks/' fixture");
-
-        debug!("Remove '{}'", self.base_dir.path().display());
         remove_dir_all(self.base_dir.path()).expect("Failed to close base directory fixture");
+    }
+}
+
+#[derive(Debug)]
+pub struct FakeConfigDirBuilder {
+    base_dir: TempDir,
+    hooks_dir: TempDir,
+    repos_dir: TempDir,
+    ignores_dir: TempDir,
+    stub_files: HashMap<PathBuf, FileStub>,
+}
+
+impl FakeConfigDirBuilder {
+    pub fn new() -> Self {
+        let base_dir =
+            Builder::new().prefix("ricer").tempdir().expect("Failed to create base directory");
+
+        let hooks_dir = Builder::new()
+            .prefix("hooks")
+            .tempdir_in(base_dir.path())
+            .expect("Failed to create 'hooks' directory");
+
+        let repos_dir = Builder::new()
+            .prefix("repos")
+            .tempdir_in(base_dir.path())
+            .expect("Failed to create 'repos' directory");
+
+        let ignores_dir = Builder::new()
+            .prefix("ignores")
+            .tempdir_in(base_dir.path())
+            .expect("Failed to create 'ignores' directory");
+
+        Self { base_dir, hooks_dir, repos_dir, ignores_dir, stub_files: HashMap::default() }
+    }
+
+    pub fn ignore_file(mut self, name: impl AsRef<str>, data: impl AsRef<str>) -> Self {
+        let stub_file = FileStub::builder()
+            .path(self.ignores_dir.path().join(format!("{}.ignore", name.as_ref())))
+            .data(data.as_ref())
+            .executable(false)
+            .build();
+
+        self.stub_files.insert(stub_file.as_path().to_path_buf(), stub_file);
+        self
+    }
+
+    pub fn hook_script(mut self, name: impl AsRef<str>, data: impl AsRef<str>) -> Self {
+        let stub_file = FileStub::builder()
+            .path(self.hooks_dir.path().join(name.as_ref()))
+            .data(data.as_ref())
+            .executable(true)
+            .build();
+
+        self.stub_files.insert(stub_file.as_path().to_path_buf(), stub_file);
+        self
+    }
+
+    pub fn build(self) -> FakeConfigDir {
+        FakeConfigDir { 
+            base_dir: self.base_dir,
+            hooks_dir: self.hooks_dir,
+            repos_dir: self.repos_dir,
+            ignores_dir: self.ignores_dir,
+            stub_files: self.stub_files
+        }
     }
 }

--- a/tests/tools/fakes.rs
+++ b/tests/tools/fakes.rs
@@ -1,12 +1,14 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
 
-use std::path::Path;
 use log::debug;
 use std::fs::remove_dir_all;
+use std::path::Path;
 use tempfile::{Builder, TempDir};
 
 use ricer_core::config::ConfigDir;
+
+use crate::tools::stubs::StubFile;
 
 pub struct FakeConfigDir {
     base_dir: TempDir,
@@ -17,10 +19,8 @@ pub struct FakeConfigDir {
 
 impl FakeConfigDir {
     pub fn new() -> Self {
-        let base_dir = Builder::new()
-            .prefix("ricer")
-            .tempdir()
-            .expect("Failed to create base directory");
+        let base_dir =
+            Builder::new().prefix("ricer").tempdir().expect("Failed to create base directory");
 
         let hooks_dir = Builder::new()
             .prefix("hooks")

--- a/tests/tools/mod.rs
+++ b/tests/tools/mod.rs
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
+
+pub mod stubs;
+
+pub mod fakes;

--- a/tests/tools/stubs.rs
+++ b/tests/tools/stubs.rs
@@ -1,62 +1,216 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
 
-use log::debug;
+// Test stub management.
+//
+// This helper module is responsible for managing stubs for integration tests
+// in Ricer.
+
 use std::fs::{metadata, set_permissions, write};
 use std::path::{PathBuf, Path};
 
-pub struct StubFile {
+// Basic stub of `std::fs::File`.
+//
+// The `std::fs::File` struct handler does not keep track of the path it is
+// operating on, nor does it keep track of a file being executable. This super
+// basic stub of `std::fs::File` is meant to provide this functionality to make
+// integration tests easier in the long run, while providing the ability to
+// write and read data.
+//
+// It keeps the data the caller wrote to a target file with this stub file
+// handler in case the user wants to compare how well there test results read
+// the target file. Thus, avoiding the need to reread the file with this stub
+// file handler.
+#[derive(Debug)]
+pub struct FileStub {
+    // Absolute path to a target file to create and write too.
     path: PathBuf,
+
+    // Data to write and keep around to a target file.
     data: String,
+
+    // Determine if a file is executable or not. Useful for defining shell
+    // scripts.
     executable: bool,
 }
 
-impl StubFile {
-    pub fn builder() -> StubFileBuilder {
-        StubFileBuilder::new()
+impl FileStub {
+    // Construct new builder instance.
+    //
+    // Postconditions:
+    //
+    // 1. Get valid instance of `FileStubBuilder`.
+    //
+    // Examples:
+    //
+    // ```
+    // use crate::tools::stubs::FileStub;
+    //
+    // let file_stub_builder = FileStub::builder();
+    // ```
+    pub fn builder() -> FileStubBuilder {
+        FileStubBuilder::new()
     }
 
+    // Get path of stub file handler.
+    //
+    // Examples:
+    //
+    // ```
+    // use crate::tools::stubs::FileStub;
+    //
+    // let file_stub = FileStub::builder()
+    //     .path("/some/where.txt")
+    //     .build()
+    // let file_path = file_stub.as_path();
+    // ```
     pub fn as_path(&self) -> &Path {
         self.path.as_path()
     }
 
+    // Get data written to target file.
+    //
+    // Pitfalls:
+    //
+    // 1. May be out of sync if external method modifies the target file that
+    //    `FileStub` instance is handling.
+    //
+    // Examples:
+    //
+    // ```
+    // use crate::tools::stubs::FileStub;
+    //
+    // let file_stub = FileStub::builder()
+    //     .path("/some/where.txt")
+    //     .data("Hello world!")
+    //     .build();
+    // let file_data = file_stub.data();
+    // ```
     pub fn data(&self) -> &str {
         self.data.as_ref()
     }
 
+    // Check if file is executable.
+    //
+    // Examples:
+    //
+    // ```
+    // use crate::tools::stubs::FileStub;
+    //
+    // let file_stub = FileStub::builder()
+    //     .path("/some/where.txt")
+    //     .executable(true)
+    //     .build();
+    // let file_exe = file_stub.is_executable();
+    // ```
     pub fn is_executable(&self) -> bool {
         self.executable
     }
 }
 
-pub struct StubFileBuilder {
+#[derive(Debug)]
+pub struct FileStubBuilder {
     path: PathBuf,
     data: String,
     executable: bool,
 }
 
-impl StubFileBuilder {
+impl FileStubBuilder {
+    // Construct new instance of file stub builder.
+    //
+    // # Postconditions:
+    //
+    // 1. Get valid instance of default file stub builder.
+    //
+    // # Invariants:
+    //
+    // 1. Do not leave any fields uninitialized without a sane default value.
+    //
+    // # Note:
+    //
+    // Caller should use `FileStub::builder()` instead of directly calling this
+    // method. That way they can use `FileStub` more directly. Unless they need
+    // the file stub instance separate from their file stub builder instance for
+    // whatever reason (unlikely but possible).
+    //
+    // # Examples:
+    //
+    // ```
+    // use crate::tools::stubs::FileStubBuilder;
+    //
+    // let builder = FileStubBuilder::new();
+    // ```
     pub fn new() -> Self {
         Self { path: PathBuf::default(), data: String::default(), executable: false }
     }
 
+    // Set path to a target file.
+    //
+    // Examples:
+    //
+    // ```
+    // use crate::tools::stubs::FileStubBuilder;
+    //
+    // let builder = FileStubBuilder::new()
+    //     .path("/some/where.txt");
+    // ```
     pub fn path(mut self, path: impl AsRef<Path>) -> Self {
         self.path = path.as_ref().to_path_buf();
         self
     }
 
+    // Set data to write into target file.
+    //
+    // Examples:
+    //
+    // ```
+    // use crate::tools::stubs::FileStubBuilder;
+    //
+    // let builder = FileStubBuilder::new()
+    //     .path("/some/where.txt")
+    //     .data("Hello world!");
+    // ```
     pub fn data(mut self, data: impl AsRef<str>) -> Self {
         self.data = data.as_ref().to_string();
         self
     }
 
+    // Make target file executable.
+    //
+    // Examples:
+    //
+    // ```
+    // use crate::tools::stubs::FileStubBuilder;
+    //
+    // let builder = FileStubBuilder::new()
+    //     .path("/some/where.txt")
+    //     .executable(true);
+    // ```
     pub fn executable(mut self, flag: bool) -> Self {
         self.executable = flag;
         self
     }
 
-    pub fn build(self) -> StubFile {
-        debug!("Write data to stub file: '{}'", self.path.display());
+    // Build instance of `FileStub`.
+    //
+    // Panics if it cannot create `FileStub` instance.
+    //
+    // Postconditions:
+    //
+    // 1. Create valid instance of `FileStub`.
+    //
+    // Examples:
+    //
+    // ```
+    // use crate::tools::stubs::FileStubBuilder;
+    //
+    // let file_stub = FileStubBuilder::new()
+    //     .path("/some/where.txt")
+    //     .data("Hello world")
+    //     .executable(true)
+    //     .build();
+    // ```
+    pub fn build(self) -> FileStub {
         write(&self.path, &self.data).unwrap_or_else(|error| {
             panic!("Failed to create file '{}': {}", self.path.display(), error)
         });
@@ -72,6 +226,6 @@ impl StubFileBuilder {
             set_permissions(&self.path, perms).unwrap();
         }
 
-        StubFile { path: self.path, data: self.data, executable: self.executable }
+        FileStub { path: self.path, data: self.data, executable: self.executable }
     }
 }

--- a/tests/tools/stubs.rs
+++ b/tests/tools/stubs.rs
@@ -118,22 +118,22 @@ pub struct FileStubBuilder {
 impl FileStubBuilder {
     // Construct new instance of file stub builder.
     //
-    // # Postconditions:
+    // Postconditions:
     //
     // 1. Get valid instance of default file stub builder.
     //
-    // # Invariants:
+    // Invariants:
     //
     // 1. Do not leave any fields uninitialized without a sane default value.
     //
-    // # Note:
+    // Note:
     //
     // Caller should use `FileStub::builder()` instead of directly calling this
     // method. That way they can use `FileStub` more directly. Unless they need
     // the file stub instance separate from their file stub builder instance for
     // whatever reason (unlikely but possible).
     //
-    // # Examples:
+    // Examples:
     //
     // ```
     // use crate::tools::stubs::FileStubBuilder;

--- a/tests/tools/stubs.rs
+++ b/tests/tools/stubs.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
 
+use log::debug;
 use std::fs::{metadata, set_permissions, write};
 use std::path::{PathBuf, Path};
 
@@ -55,6 +56,7 @@ impl StubFileBuilder {
     }
 
     pub fn build(self) -> StubFile {
+        debug!("Write data to stub file: '{}'", self.path.display());
         write(&self.path, &self.data).unwrap_or_else(|error| {
             panic!("Failed to create file '{}': {}", self.path.display(), error)
         });

--- a/tests/tools/stubs.rs
+++ b/tests/tools/stubs.rs
@@ -6,7 +6,7 @@
 // This helper module is responsible for managing stubs for integration tests
 // in Ricer.
 
-use std::fs::{metadata, set_permissions, write};
+use std::fs::{create_dir, metadata, set_permissions, write};
 use std::path::{Path, PathBuf};
 
 // Basic stub of `std::fs::File`.
@@ -227,5 +227,37 @@ impl FileStubBuilder {
         }
 
         FileStub { path: self.path, data: self.data, executable: self.executable }
+    }
+}
+
+// Basic stub of a Git repository.
+//
+// Mainly used to provide basic Git repository stubs for integration testing
+// with `FakeConfigDir`.
+#[derive(Debug)]
+pub struct GitRepoStub {
+    // Absolute path to Git repository stub.
+    path: PathBuf,
+}
+
+impl GitRepoStub {
+    // Create new Git repository stub instance.
+    //
+    // Postconditions:
+    //
+    // 1. Create Git repository in target path.
+    //
+    // Errors:
+    //
+    // Panics if it cannot create Git repository.
+    pub fn new(path: impl AsRef<Path>) -> Self {
+        // TODO: Make this stub more like a Git repo rather than an empty dir...
+        create_dir(path.as_ref()).expect("Failed to create repository");
+        Self { path: path.as_ref().to_path_buf() }
+    }
+
+    // Get path to Git repository stub.
+    pub fn as_path(&self) -> &Path {
+        self.path.as_path()
     }
 }

--- a/tests/tools/stubs.rs
+++ b/tests/tools/stubs.rs
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
+
+use std::fs::{metadata, set_permissions, write};
+use std::path::{PathBuf, Path};
+
+pub struct StubFile {
+    path: PathBuf,
+    data: String,
+    executable: bool,
+}
+
+impl StubFile {
+    pub fn builder() -> StubFileBuilder {
+        StubFileBuilder::new()
+    }
+
+    pub fn as_path(&self) -> &Path {
+        self.path.as_path()
+    }
+
+    pub fn data(&self) -> &str {
+        self.data.as_ref()
+    }
+
+    pub fn is_executable(&self) -> bool {
+        self.executable
+    }
+}
+
+pub struct StubFileBuilder {
+    path: PathBuf,
+    data: String,
+    executable: bool,
+}
+
+impl StubFileBuilder {
+    pub fn new() -> Self {
+        Self { path: PathBuf::default(), data: String::default(), executable: false }
+    }
+
+    pub fn path(mut self, path: impl AsRef<Path>) -> Self {
+        self.path = path.as_ref().to_path_buf();
+        self
+    }
+
+    pub fn data(mut self, data: impl AsRef<str>) -> Self {
+        self.data = data.as_ref().to_string();
+        self
+    }
+
+    pub fn executable(mut self, flag: bool) -> Self {
+        self.executable = flag;
+        self
+    }
+
+    pub fn build(self) -> StubFile {
+        write(&self.path, &self.data).unwrap_or_else(|error| {
+            panic!("Failed to create file '{}': {}", self.path.display(), error)
+        });
+
+        #[cfg(unix)]
+        if self.executable {
+            use std::os::unix::fs::PermissionsExt;
+
+            let mut perms = metadata(&self.path).unwrap().permissions();
+            let mode = perms.mode();
+
+            perms.set_mode(mode | 0o111);
+            set_permissions(&self.path, perms).unwrap();
+        }
+
+        StubFile { path: self.path, data: self.data, executable: self.executable }
+    }
+}

--- a/tests/tools/stubs.rs
+++ b/tests/tools/stubs.rs
@@ -7,7 +7,7 @@
 // in Ricer.
 
 use std::fs::{metadata, set_permissions, write};
-use std::path::{PathBuf, Path};
+use std::path::{Path, PathBuf};
 
 // Basic stub of `std::fs::File`.
 //


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

The new `ricer_core::config::Config` struct allows the core internal API to manage the configuration directory of the Ricer binary.
Took a while to develop due to issues with testing, which required some custom test tooling to confirm functionality of this module.

## Area of Effect

- Test module `tools`.
- Test module `config`.
- Production module `config`.

## Tasks

- [x] Add a way to fake the configuration directory.
- [x] Stub `std::fs::File`.
- [x] Implement `ricer_core::config::Config`.
- [x] Test `ricer_core::config::Config` methods.
