### PR TITLE
Setup configuration directory manager

### DIFF
--- a/src/bin/ricer.rs
+++ b/src/bin/ricer.rs
@@ -11,6 +11,7 @@ use log::error;
 use std::ffi::OsString;
 
 use ricer::cli::RicerCli;
+use ricer::config::dir::{ConfigDirManager, DefaultConfigDirManager};
 use ricer::config::locator::{
     recover_default_config_dir_locator, DefaultConfigDirLocator, DefaultXdgBaseDirSpec,
 };
@@ -57,11 +58,13 @@ where
 
     let _ctx = Context::from(opts);
     let xdg_spec = DefaultXdgBaseDirSpec::try_new()?;
-    let _locator = match DefaultConfigDirLocator::try_new_locate(&xdg_spec) {
+    let locator = match DefaultConfigDirLocator::try_new_locate(&xdg_spec) {
         Ok(locator) => locator,
         Err(RicerError::NoConfigDir(..)) => recover_default_config_dir_locator(&xdg_spec)?,
         Err(err) => return Err(err.into()),
     };
+    let cfg_dir_mgr = DefaultConfigDirManager::new(&locator);
+    println!("{}", cfg_dir_mgr.root_dir().display());
 
     // TODO: match and execute command in Ricer's command set...
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,58 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
 
-//! Configuration data management.
-//!
-//! This module is responsible for providing an interface for managing Ricer's
-//! configuration data.
-//!
-//! Ricer uses `$XDG_CONFIG_HOME/ricer` to house all of its configuration
-//! information. The following represents the overall structure of this
-//! directory:
-//!
-//! ```markdown
-//! $XDG_CONFIG_HOME/ricer/
-//! |-- hooks/
-//! |   |-- hook_script1.sh
-//! |   |-- hook_script2.sh
-//! |   `-- hook_scriptn.sh
-//! |-- repos/
-//! |   |-- config1.git/
-//! |   |-- config2.git/
-//! |   `-- confign.git/
-//! |-- ignores/
-//! |   |-- config1.ignore
-//! |   |-- config2.ignore
-//! |   `-- confign.ignore
-//! `-- config.toml
-//! ```
-//!
-//! The `config.toml` file is the main configuration file for Ricer. The user
-//! can directly modify this configuration file through their preferred text
-//! editor. However, the user can indirectly modify `config.toml` through
-//! Ricer's command set, e.g., init and clone.
-//!
-//! The `hooks/` directory contains all scripts that the user can use as hooks
-//! for Ricer's command set. Ricer _will_ only execute hooks stored in this
-//! directory. Thus, the user can refer to hook scripts by name without the need
-//! to provide an absolute or relative path, because Ricer will automatically
-//! look in the `hooks/` directory for any hook scripts the user wants.
-//!
-//! > __NOTE:__ The limiting of hook scripts to the `hook/` directory is done
-//! > as a very basic security measure. The hope is that the user can easily
-//! > identify potentially dangerious hook scripts by centeralizing all scripts
-//! > in one easily accessible location.
-//!
-//! The `repos/` directory contains all the cloned and initialized repositories
-//! the user wants Ricer to keep track of. This directory is where Ricer finds
-//! and modifies repository information the user passes in through the CLI.
-//!
-//! Finally, the `ignores/` directory houses exclude/ignore files that ensure
-//! that each repository in `repos/` only tracks the portions of the user's
-//! home directory that they are responsible for. This ensures that no
-//! repository the user is tracking through Ricer attempts to track their
-//! entire home directory.
-
+pub mod dir;
 pub mod file;
 pub mod locator;
 

--- a/src/config/dir.rs
+++ b/src/config/dir.rs
@@ -95,7 +95,7 @@ impl DefaultConfigDirManager {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// # use anyhow::Result;
     /// # fn main() -> Result<()> {
     /// use ricer::config::locator::{DefaultXdgBaseDirSpec, DefaultConfigDirLocator};

--- a/src/config/dir.rs
+++ b/src/config/dir.rs
@@ -67,6 +67,9 @@ pub trait ConfigDirManager {
     /// Find absolute path to hook script.
     fn try_find_hook_script(&self, hook_name: impl AsRef<str>) -> RicerResult<PathBuf>;
 
+    /// Find absolute path to ignore file.
+    fn try_find_ignore_file(&self, repo_name: impl AsRef<str>) -> RicerResult<PathBuf>;
+
     /// Absolute path to root/top-level configuration directory.
     fn root_dir(&self) -> &Path;
 
@@ -149,6 +152,18 @@ impl ConfigDirManager for DefaultConfigDirManager {
         }
 
         Ok(hook_path)
+    }
+
+    fn try_find_ignore_file(&self, repo_name: impl AsRef<str>) -> RicerResult<PathBuf> {
+        let ignore_path = self.ignores_dir.join(format!("{}.ignore", repo_name.as_ref()));
+        if !ignore_path.exists() {
+            return Err(RicerError::Unrecoverable(anyhow!(
+                "Ignore file '{}' does not exist",
+                ignore_path.display()
+            )));
+        }
+
+        Ok(ignore_path)
     }
 
     fn root_dir(&self) -> &Path {

--- a/src/config/dir.rs
+++ b/src/config/dir.rs
@@ -64,6 +64,9 @@ pub trait ConfigDirManager {
     /// Find absolute path to Git repository.
     fn try_find_git_repo(&self, repo_name: impl AsRef<str>) -> RicerResult<PathBuf>;
 
+    /// Find absolute path to hook script.
+    fn try_find_hook_script(&self, hook_name: impl AsRef<str>) -> RicerResult<PathBuf>;
+
     /// Absolute path to root/top-level configuration directory.
     fn root_dir(&self) -> &Path;
 
@@ -134,6 +137,18 @@ impl ConfigDirManager for DefaultConfigDirManager {
         }
 
         Ok(repo_path)
+    }
+
+    fn try_find_hook_script(&self, hook_name: impl AsRef<str>) -> RicerResult<PathBuf> {
+        let hook_path = self.hooks_dir.join(hook_name.as_ref());
+        if !hook_path.exists() {
+            return Err(RicerError::Unrecoverable(anyhow!(
+                "Hook script '{}' does not exist",
+                hook_path.display()
+            )));
+        }
+
+        Ok(hook_path)
     }
 
     fn root_dir(&self) -> &Path {

--- a/src/config/dir.rs
+++ b/src/config/dir.rs
@@ -50,7 +50,7 @@
 //! repository the user is tracking through Ricer attempts to track their
 //! entire home directory.
 
-use std::path::{PathBuf, Path};
+use std::path::{Path, PathBuf};
 
 use crate::config::locator::ConfigDirLocator;
 use crate::error::RicerResult;
@@ -68,4 +68,56 @@ pub trait ConfigDirManager {
 
     /// Absolute path to ignore files directory.
     fn ignores_dir(&self) -> &Path;
+}
+
+pub struct DefaultConfigDirManager {
+    root_dir: PathBuf,
+    repos_dir: PathBuf,
+    hooks_dir: PathBuf,
+    ignores_dir: PathBuf,
+}
+
+impl DefaultConfigDirManager {
+    /// Construct new default configuration directory manager.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use anyhow::Result;
+    /// # fn main() -> Result<()> {
+    /// use ricer::config::locator::{DefaultXdgBaseDirSpec, DefaultConfigDirLocator};
+    /// use ricer::config::dir::DefaultConfigDirManager;
+    ///
+    /// let xdg_spec = DefaultXdgBaseDirSpec::try_new()?;
+    /// let locator = DefaultConfigDirLocator::try_new_locate(&xdg_spec)?;
+    /// let cfg_dir_mgr = DefaultConfigDirManager::new(&locator);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new(locator: &dyn ConfigDirLocator) -> Self {
+        let root_dir = locator.config_dir().to_path_buf();
+        let repos_dir = root_dir.join("repos");
+        let hooks_dir = root_dir.join("hooks");
+        let ignores_dir = root_dir.join("ignores");
+
+        Self { root_dir, repos_dir, hooks_dir, ignores_dir }
+    }
+}
+
+impl ConfigDirManager for DefaultConfigDirManager {
+    fn root_dir(&self) -> &Path {
+        self.root_dir.as_path()
+    }
+
+    fn repos_dir(&self) -> &Path {
+        self.repos_dir.as_path()
+    }
+
+    fn hooks_dir(&self) -> &Path {
+        self.hooks_dir.as_path()
+    }
+
+    fn ignores_dir(&self) -> &Path {
+        self.ignores_dir.as_path()
+    }
 }

--- a/src/config/dir.rs
+++ b/src/config/dir.rs
@@ -50,13 +50,17 @@
 //! repository the user is tracking through Ricer attempts to track their
 //! entire home directory.
 
+use anyhow::anyhow;
 use std::path::{Path, PathBuf};
 
 use crate::config::locator::ConfigDirLocator;
-use crate::error::RicerResult;
+use crate::error::{RicerError, RicerResult};
 
 /// Configuration directory manager representation.
 pub trait ConfigDirManager {
+    /// Find absolute path to configuration file.
+    fn try_find_config_file(&self) -> RicerResult<PathBuf>;
+
     /// Absolute path to root/top-level configuration directory.
     fn root_dir(&self) -> &Path;
 
@@ -105,6 +109,18 @@ impl DefaultConfigDirManager {
 }
 
 impl ConfigDirManager for DefaultConfigDirManager {
+    fn try_find_config_file(&self) -> RicerResult<PathBuf> {
+        let cfg_file_path = self.root_dir.join("config.toml");
+        if !cfg_file_path.exists() {
+            return Err(RicerError::Unrecoverable(anyhow!(
+                "Configuration file does not exist at '{}'",
+                cfg_file_path.display()
+            )));
+        }
+
+        Ok(cfg_file_path)
+    }
+
     fn root_dir(&self) -> &Path {
         self.root_dir.as_path()
     }
@@ -121,3 +137,6 @@ impl ConfigDirManager for DefaultConfigDirManager {
         self.ignores_dir.as_path()
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/config/dir.rs
+++ b/src/config/dir.rs
@@ -61,6 +61,9 @@ pub trait ConfigDirManager {
     /// Find absolute path to configuration file.
     fn try_find_config_file(&self) -> RicerResult<PathBuf>;
 
+    /// Find absolute path to Git repository.
+    fn try_find_git_repo(&self, repo_name: impl AsRef<str>) -> RicerResult<PathBuf>;
+
     /// Absolute path to root/top-level configuration directory.
     fn root_dir(&self) -> &Path;
 
@@ -119,6 +122,18 @@ impl ConfigDirManager for DefaultConfigDirManager {
         }
 
         Ok(cfg_file_path)
+    }
+
+    fn try_find_git_repo(&self, repo_name: impl AsRef<str>) -> RicerResult<PathBuf> {
+        let repo_path = self.repos_dir.join(format!("{}.git", repo_name.as_ref()));
+        if !repo_path.exists() {
+            return Err(RicerError::Unrecoverable(anyhow!(
+                "Git repository '{}' does not exist",
+                repo_path.display()
+            )));
+        }
+
+        Ok(repo_path)
     }
 
     fn root_dir(&self) -> &Path {

--- a/src/config/dir.rs
+++ b/src/config/dir.rs
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
+
+//! Configuration directory layout management.
+//!
+//! Ricer uses `$XDG_CONFIG_HOME/ricer` to house all of its configuration
+//! information. The following represents the overall structure of this
+//! directory:
+//!
+//! ```markdown
+//! $XDG_CONFIG_HOME/ricer/
+//! |-- hooks/
+//! |   |-- hook_script1.sh
+//! |   |-- hook_script2.sh
+//! |   `-- hook_scriptn.sh
+//! |-- repos/
+//! |   |-- config1.git/
+//! |   |-- config2.git/
+//! |   `-- confign.git/
+//! |-- ignores/
+//! |   |-- config1.ignore
+//! |   |-- config2.ignore
+//! |   `-- confign.ignore
+//! `-- config.toml
+//! ```
+//!
+//! The `config.toml` file is the main configuration file for Ricer. The user
+//! can directly modify this configuration file through their preferred text
+//! editor. However, the user can indirectly modify `config.toml` through
+//! Ricer's command set, e.g., init and clone.
+//!
+//! The `hooks/` directory contains all scripts that the user can use as hooks
+//! for Ricer's command set. Ricer _will_ only execute hooks stored in this
+//! directory. Thus, the user can refer to hook scripts by name without the need
+//! to provide an absolute or relative path, because Ricer will automatically
+//! look in the `hooks/` directory for any hook scripts the user wants.
+//!
+//! > __NOTE:__ The limiting of hook scripts to the `hook/` directory is done
+//! > as a very basic security measure. The hope is that the user can easily
+//! > identify potentially dangerious hook scripts by centeralizing all scripts
+//! > in one easily accessible location.
+//!
+//! The `repos/` directory contains all the cloned and initialized repositories
+//! the user wants Ricer to keep track of. This directory is where Ricer finds
+//! and modifies repository information the user passes in through the CLI.
+//!
+//! Finally, the `ignores/` directory houses exclude/ignore files that ensure
+//! that each repository in `repos/` only tracks the portions of the user's
+//! home directory that they are responsible for. This ensures that no
+//! repository the user is tracking through Ricer attempts to track their
+//! entire home directory.
+
+use std::path::{PathBuf, Path};
+
+use crate::config::locator::ConfigDirLocator;
+use crate::error::RicerResult;
+
+/// Configuration directory manager representation.
+pub trait ConfigDirManager {
+    /// Absolute path to root/top-level configuration directory.
+    fn root_dir(&self) -> &Path;
+
+    /// Absolute path to repositories directory.
+    fn repos_dir(&self) -> &Path;
+
+    /// Absolute path to hook scripts directory.
+    fn hooks_dir(&self) -> &Path;
+
+    /// Absolute path to ignore files directory.
+    fn ignores_dir(&self) -> &Path;
+}

--- a/src/config/dir/tests.rs
+++ b/src/config/dir/tests.rs
@@ -13,6 +13,7 @@ use ricer_test_tools::fakes::FakeConfigDir;
 fn full_config_dir_fixture() -> FakeConfigDir {
     FakeConfigDir::builder()
         .config_file("fake it till you make it!")
+        .git_repo("vim")
         .build()
 }
 
@@ -43,5 +44,30 @@ fn try_find_config_file_cannot_find_config_file(empty_config_dir_fixture: FakeCo
    
     let cfg_dir_mgr = DefaultConfigDirManager::new(&mock_locator);
     let result = cfg_dir_mgr.try_find_config_file();
+    assert!(matches!(result, Err(RicerError::Unrecoverable(..))));
+}
+
+#[rstest]
+fn try_find_git_repo_finds_git_repo(full_config_dir_fixture: FakeConfigDir) {
+    let mut mock_locator = MockConfigDirLocator::new();
+    mock_locator
+        .expect_config_dir()
+        .return_const(full_config_dir_fixture.root_dir().to_path_buf());
+
+    let cfg_dir_mgr = DefaultConfigDirManager::new(&mock_locator);
+    let expect = full_config_dir_fixture.path_to_git_repo("vim").as_path();
+    let result = cfg_dir_mgr.try_find_git_repo("vim").expect("Expect success");
+    assert_eq!(expect, result);
+}
+
+#[rstest]
+fn try_find_git_repo_cannot_find_git_repo(empty_config_dir_fixture: FakeConfigDir) {
+    let mut mock_locator = MockConfigDirLocator::new();
+    mock_locator
+        .expect_config_dir()
+        .return_const(empty_config_dir_fixture.root_dir().to_path_buf());
+
+    let cfg_dir_mgr = DefaultConfigDirManager::new(&mock_locator);
+    let result = cfg_dir_mgr.try_find_git_repo("nonexistant");
     assert!(matches!(result, Err(RicerError::Unrecoverable(..))));
 }

--- a/src/config/dir/tests.rs
+++ b/src/config/dir/tests.rs
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
+
+use super::*;
+use rstest::{fixture, rstest};
+use pretty_assertions::assert_eq;
+
+use crate::config::locator::MockConfigDirLocator;
+
+use ricer_test_tools::fakes::FakeConfigDir;
+
+#[fixture]
+fn full_config_dir_fixture() -> FakeConfigDir {
+    FakeConfigDir::builder()
+        .config_file("fake it till you make it!")
+        .build()
+}
+
+#[fixture]
+fn empty_config_dir_fixture() -> FakeConfigDir {
+    FakeConfigDir::builder().build()
+}
+
+#[rstest]
+fn try_find_config_file_finds_config_file(full_config_dir_fixture: FakeConfigDir) {
+    let mut mock_locator = MockConfigDirLocator::new();
+    mock_locator
+        .expect_config_dir()
+        .return_const(full_config_dir_fixture.root_dir().to_path_buf());
+
+    let cfg_dir_mgr = DefaultConfigDirManager::new(&mock_locator);
+    let expect = full_config_dir_fixture.path_to_config_file().as_path();
+    let result = cfg_dir_mgr.try_find_config_file().expect("Expect success");
+    assert_eq!(expect, result);
+}
+
+#[rstest]
+fn try_find_config_file_cannot_find_config_file(empty_config_dir_fixture: FakeConfigDir) {
+    let mut mock_locator = MockConfigDirLocator::new();
+    mock_locator
+        .expect_config_dir()
+        .return_const(empty_config_dir_fixture.root_dir().to_path_buf());
+   
+    let cfg_dir_mgr = DefaultConfigDirManager::new(&mock_locator);
+    let result = cfg_dir_mgr.try_find_config_file();
+    assert!(matches!(result, Err(RicerError::Unrecoverable(..))));
+}

--- a/src/config/dir/tests.rs
+++ b/src/config/dir/tests.rs
@@ -15,6 +15,7 @@ fn full_config_dir_fixture() -> FakeConfigDir {
         .config_file("fake it till you make it!")
         .git_repo("vim")
         .hook_script("hook.sh", "fake it till you make it!")
+        .ignore_file("vim", "fake it till you make it!")
         .build()
 }
 
@@ -95,5 +96,30 @@ fn try_find_hook_script_cannot_find_hook_script(empty_config_dir_fixture: FakeCo
 
     let cfg_dir_mgr = DefaultConfigDirManager::new(&mock_locator);
     let result = cfg_dir_mgr.try_find_hook_script("nonexistant");
+    assert!(matches!(result, Err(RicerError::Unrecoverable(..))));
+}
+
+#[rstest]
+fn try_find_ignore_file_finds_ignore_file(full_config_dir_fixture: FakeConfigDir) {
+    let mut mock_locator = MockConfigDirLocator::new();
+    mock_locator
+        .expect_config_dir()
+        .return_const(full_config_dir_fixture.root_dir().to_path_buf());
+
+    let cfg_dir_mgr = DefaultConfigDirManager::new(&mock_locator);
+    let expect = full_config_dir_fixture.path_to_ignore_file("vim").as_path();
+    let result = cfg_dir_mgr.try_find_ignore_file("vim").expect("Expect success");
+    assert_eq!(expect, result);
+}
+
+#[rstest]
+fn try_find_ignore_file_cannot_find_ignore_file(empty_config_dir_fixture: FakeConfigDir) {
+    let mut mock_locator = MockConfigDirLocator::new();
+    mock_locator
+        .expect_config_dir()
+        .return_const(empty_config_dir_fixture.root_dir().to_path_buf());
+
+    let cfg_dir_mgr = DefaultConfigDirManager::new(&mock_locator);
+    let result = cfg_dir_mgr.try_find_ignore_file("nonexistant");
     assert!(matches!(result, Err(RicerError::Unrecoverable(..))));
 }

--- a/src/config/dir/tests.rs
+++ b/src/config/dir/tests.rs
@@ -14,6 +14,7 @@ fn full_config_dir_fixture() -> FakeConfigDir {
     FakeConfigDir::builder()
         .config_file("fake it till you make it!")
         .git_repo("vim")
+        .hook_script("hook.sh", "fake it till you make it!")
         .build()
 }
 
@@ -69,5 +70,30 @@ fn try_find_git_repo_cannot_find_git_repo(empty_config_dir_fixture: FakeConfigDi
 
     let cfg_dir_mgr = DefaultConfigDirManager::new(&mock_locator);
     let result = cfg_dir_mgr.try_find_git_repo("nonexistant");
+    assert!(matches!(result, Err(RicerError::Unrecoverable(..))));
+}
+
+#[rstest]
+fn try_find_hook_script_finds_hook_script(full_config_dir_fixture: FakeConfigDir) {
+    let mut mock_locator = MockConfigDirLocator::new();
+    mock_locator
+        .expect_config_dir()
+        .return_const(full_config_dir_fixture.root_dir().to_path_buf());
+
+    let cfg_dir_mgr = DefaultConfigDirManager::new(&mock_locator);
+    let expect = full_config_dir_fixture.path_to_hook_script("hook.sh").as_path();
+    let result = cfg_dir_mgr.try_find_hook_script("hook.sh").expect("Expect success");
+    assert_eq!(expect, result);
+}
+
+#[rstest]
+fn try_find_hook_script_cannot_find_hook_script(empty_config_dir_fixture: FakeConfigDir) {
+    let mut mock_locator = MockConfigDirLocator::new();
+    mock_locator
+        .expect_config_dir()
+        .return_const(empty_config_dir_fixture.root_dir().to_path_buf());
+
+    let cfg_dir_mgr = DefaultConfigDirManager::new(&mock_locator);
+    let result = cfg_dir_mgr.try_find_hook_script("nonexistant");
     assert!(matches!(result, Err(RicerError::Unrecoverable(..))));
 }

--- a/src/config/dir/tests.rs
+++ b/src/config/dir/tests.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
 
 use super::*;
-use rstest::{fixture, rstest};
 use pretty_assertions::assert_eq;
+use rstest::{fixture, rstest};
 
 use crate::config::locator::MockConfigDirLocator;
 
@@ -27,9 +27,7 @@ fn empty_config_dir_fixture() -> FakeConfigDir {
 #[rstest]
 fn try_find_config_file_finds_config_file(full_config_dir_fixture: FakeConfigDir) {
     let mut mock_locator = MockConfigDirLocator::new();
-    mock_locator
-        .expect_config_dir()
-        .return_const(full_config_dir_fixture.root_dir().to_path_buf());
+    mock_locator.expect_config_dir().return_const(full_config_dir_fixture.root_dir().to_path_buf());
 
     let cfg_dir_mgr = DefaultConfigDirManager::new(&mock_locator);
     let expect = full_config_dir_fixture.path_to_config_file().as_path();
@@ -43,7 +41,7 @@ fn try_find_config_file_cannot_find_config_file(empty_config_dir_fixture: FakeCo
     mock_locator
         .expect_config_dir()
         .return_const(empty_config_dir_fixture.root_dir().to_path_buf());
-   
+
     let cfg_dir_mgr = DefaultConfigDirManager::new(&mock_locator);
     let result = cfg_dir_mgr.try_find_config_file();
     assert!(matches!(result, Err(RicerError::Unrecoverable(..))));
@@ -52,9 +50,7 @@ fn try_find_config_file_cannot_find_config_file(empty_config_dir_fixture: FakeCo
 #[rstest]
 fn try_find_git_repo_finds_git_repo(full_config_dir_fixture: FakeConfigDir) {
     let mut mock_locator = MockConfigDirLocator::new();
-    mock_locator
-        .expect_config_dir()
-        .return_const(full_config_dir_fixture.root_dir().to_path_buf());
+    mock_locator.expect_config_dir().return_const(full_config_dir_fixture.root_dir().to_path_buf());
 
     let cfg_dir_mgr = DefaultConfigDirManager::new(&mock_locator);
     let expect = full_config_dir_fixture.path_to_git_repo("vim").as_path();
@@ -77,9 +73,7 @@ fn try_find_git_repo_cannot_find_git_repo(empty_config_dir_fixture: FakeConfigDi
 #[rstest]
 fn try_find_hook_script_finds_hook_script(full_config_dir_fixture: FakeConfigDir) {
     let mut mock_locator = MockConfigDirLocator::new();
-    mock_locator
-        .expect_config_dir()
-        .return_const(full_config_dir_fixture.root_dir().to_path_buf());
+    mock_locator.expect_config_dir().return_const(full_config_dir_fixture.root_dir().to_path_buf());
 
     let cfg_dir_mgr = DefaultConfigDirManager::new(&mock_locator);
     let expect = full_config_dir_fixture.path_to_hook_script("hook.sh").as_path();
@@ -102,9 +96,7 @@ fn try_find_hook_script_cannot_find_hook_script(empty_config_dir_fixture: FakeCo
 #[rstest]
 fn try_find_ignore_file_finds_ignore_file(full_config_dir_fixture: FakeConfigDir) {
     let mut mock_locator = MockConfigDirLocator::new();
-    mock_locator
-        .expect_config_dir()
-        .return_const(full_config_dir_fixture.root_dir().to_path_buf());
+    mock_locator.expect_config_dir().return_const(full_config_dir_fixture.root_dir().to_path_buf());
 
     let cfg_dir_mgr = DefaultConfigDirManager::new(&mock_locator);
     let expect = full_config_dir_fixture.path_to_ignore_file("vim").as_path();

--- a/src/config/locator.rs
+++ b/src/config/locator.rs
@@ -22,6 +22,7 @@ use mockall::automock;
 use crate::error::{RicerError, RicerResult};
 
 /// Configuration directory locator representation.
+#[cfg_attr(test, automock)]
 pub trait ConfigDirLocator {
     /// Provide absolute path to located configuration directory.
     fn config_dir(&self) -> &Path;

--- a/tests/tools/src/fakes.rs
+++ b/tests/tools/src/fakes.rs
@@ -36,6 +36,30 @@ impl FakeConfigDir {
         FakeConfigDirBuilder::new()
     }
 
+    /// Get stored path to target fake configuration file at top-level.
+    ///
+    /// # Errors
+    ///
+    /// Panics if ignore file is not being tracked by fake configuration
+    /// directory.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ricer_test_tools::fakes::FakeConfigDir;
+    ///
+    /// let config = FakeConfigDir::builder()
+    ///     .config_file("sample config data")
+    ///     .build();
+    /// let path = config.path_to_config_file();
+    /// ```
+    pub fn path_to_config_file(&self) -> &FileStub {
+        match self.file_stubs.get(&self.root_dir.join("config.toml")) {
+            Some(file) => file,
+            None => panic!("Configuration file is not being tracked by fake directory"),
+        }
+    }
+
     /// Get stored path to target fake ignore file in 'ignores' directory.
     ///
     /// Ignore files in Ricer are named after repositories in the `repos`
@@ -59,7 +83,7 @@ impl FakeConfigDir {
     /// use ricer_test_tools::fakes::FakeConfigDir;
     ///
     /// let config = FakeConfigDir::builder()
-    ///     .ignore_file("fake_ignore", "/*") /// Stored as 'fake_ignore.ignore'
+    ///     .ignore_file("fake_ignore", "/*") // Stored as 'fake_ignore.ignore'
     ///     .build();
     /// let path = config.path_to_ignore_file("fake_ignore");
     /// ```


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

Implementation of a basic configuration directory manager that handles the layout and file data meant to be stored in Ricer's configuration directory.

## Area of Effect

- Module `ricer::config::dir`
- Module `ricer_test_tools::fakes`
