### PR TITLE
Implement way to parse `repos` section of configuration file

### DIFF
--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -1,72 +1,35 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
 
-//! Format of Ricer's configuration file.
+//! Configuration file management.
 //!
-//! Ricer uses a special configuration file named `config.toml` in its base
-//! directory in `$XDG_CONFIG_HOME/ricer`. This configuration file uses the
-//! [TOML format][toml-spec] so the user can modify it by hand in case they do
-//! not want to go through Ricer's command set for whatever reason.
+//! This module provides a simple interface to manipulate and manage Ricer's
+//! configuration file. Ricer uses a special configuration file named
+//! `config.toml` in its base directory in `$XDG_CONFIG_HOME/ricer`. This
+//! configuration file uses the [TOML format[toml-spec] so the user can modify
+//! it by hand in case they do not want to go through Ricer's command set for
+//! whatever reason.
+//!
+//! [toml-spec]: https://toml.io/en/v1.0.0
 
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::path::Path;
 
-/// Currently Ricer's configuration file is comprised of two major tables:
-/// `repos` and `hooks`. The `repos` table houses configuration information for
-/// repositories Ricer is tracking. The `hooks` table is where the user can
-/// define their custom command hooks.
-///
-/// [toml-spec]: https://toml.io/en/v1.0.0
-#[derive(Debug, Default, Deserialize, PartialEq, Serialize)]
-pub struct ConfigFile {
-    /// Current Git repositories Ricer is tracking.
-    pub repos: Option<HashMap<String, ReposTable>>,
+pub mod repos_section;
 
-    /// Current command hooks to execute.
-    pub hooks: Option<HooksTable>,
-}
+use crate::error::RicerResult;
+use repos_section::RepoEntry;
 
-#[derive(Debug, Default, Deserialize, PartialEq, Serialize)]
-pub struct ReposTable {
-    /// Make repository use the user's home directory as the working tree.
-    pub target_home: bool,
+/// Configuration file manager representation.
+pub trait ConfigFileManager {
+    /// Read from configuration file at provided path.
+    fn read(&mut self, path: impl AsRef<Path>) -> RicerResult<()>;
 
-    /// Branch to use for all commands.
-    pub main_branch: String,
+    /// Write to configuration file at provided path.
+    fn write(&mut self, path: impl AsRef<Path>) -> RicerResult<()>;
 
-    /// Remote to use for all commands.
-    pub main_remote: String,
-}
+    /// Show current configuration file data in string form.
+    fn data(&self) -> String;
 
-/// Command hooks.
-#[derive(Debug, Default, Deserialize, PartialEq, Serialize)]
-pub struct HooksTable {
-    pub commit: Option<Vec<HookConfig>>,
-    pub push: Option<Vec<HookConfig>>,
-    pub pull: Option<Vec<HookConfig>>,
-    pub init: Option<Vec<HookConfig>>,
-    pub clone: Option<Vec<HookConfig>>,
-    pub delete: Option<Vec<HookConfig>>,
-    pub rename: Option<Vec<HookConfig>>,
-    pub status: Option<Vec<HookConfig>>,
-    pub list: Option<Vec<HookConfig>>,
-    pub enter: Option<Vec<HookConfig>>,
-}
-
-/// Hook configuration.
-///
-/// Hooks are only found and executed from the `hooks` directory in Ricer's
-/// base directory. The user only needs to specify the hook by its filename.
-/// So if a hook script `$XDG_CONFIG_HOME/ricer/hooks/hook.sh` exists, then the
-/// user can specify it as just `hook.sh`.
-#[derive(Debug, Default, Deserialize, PartialEq, Serialize)]
-pub struct HookConfig {
-    /// Execute hook _before_ running the Ricer command.
-    pub pre: Option<String>,
-
-    /// Execute hook _after_ running the Ricer command.
-    pub post: Option<String>,
-
-    /// Execute the hook _only_ for a target repository.
-    pub repo: Option<String>,
+    /// Deserialize repository entry from parsed configuration file data.
+    fn get_repo_entry(&self, repo_name: impl AsRef<str>) -> Option<RepoEntry>;
 }

--- a/src/config/file/repos_section.rs
+++ b/src/config/file/repos_section.rs
@@ -30,6 +30,14 @@
 //! _macos_, _windows_, or _any_. The `user` and `hostname` fields will make
 //! Ricer only bootstrap a repository for a specific user and host.
 
+use log::trace;
+
+/// Repository entry definition implementation.
+///
+/// # Invariants
+///
+/// 1. No field is empty.
+#[derive(Debug, Default, Eq, PartialEq)]
 pub struct RepoEntry {
     /// Name of repository. Also used to name the cloned repository in the
     /// `repos` directory.
@@ -48,6 +56,126 @@ pub struct RepoEntry {
     pub target: RepoTargetEntry,
 }
 
+impl RepoEntry {
+    /// Build new repository entry definition.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Return [`RepoEntryBuilder`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer::config::file::repos_section::RepoEntry;
+    ///
+    /// let repo_builder = RepoEntry::builder("vim:");
+    /// ```
+    pub fn builder(name: impl AsRef<str>) -> RepoEntryBuilder {
+        RepoEntryBuilder::new(name)
+    }
+}
+
+/// Repository entry builder.
+///
+/// Generally exists to make repository entry definitions much easier in the
+/// future!
+///
+/// # Invariants
+///
+/// 1. No field is empty.
+#[derive(Debug, Default)]
+pub struct RepoEntryBuilder {
+    name: String,
+    branch: String,
+    remote: String,
+    url: String,
+    target: RepoTargetEntry,
+}
+
+impl RepoEntryBuilder {
+    /// Construct repository entry builder.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Return new instance of repository entry builder.
+    ///
+    /// ```no_run
+    /// use ricer::config::file::repos_section::RepoEntryBuilder;
+    ///
+    /// let repo_builder = RepoEntryBuilder::new("vim");
+    /// ```
+    pub fn new(name: impl AsRef<str>) -> Self {
+        Self {
+            name: name.as_ref().to_string(),
+            branch: Default::default(),
+            remote: Default::default(),
+            url: Default::default(),
+            target: Default::default(),
+        }
+    }
+
+    pub fn branch(mut self, branch: impl AsRef<str>) -> Self {
+        self.branch = branch.as_ref().to_string();
+        self
+    }
+
+    pub fn remote(mut self, remote: impl AsRef<str>) -> Self {
+        self.remote = remote.as_ref().to_string();
+        self
+    }
+
+    pub fn url(mut self, url: impl AsRef<str>) -> Self {
+        self.url = url.as_ref().to_string();
+        self
+    }
+
+    pub fn target(mut self, target: RepoTargetEntry) -> Self {
+        self.target = target;
+        self
+    }
+
+    /// Build new [`RepoEntry`].
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Valid instance of [`RepoEntry`].
+    ///
+    /// # Invariants
+    ///
+    /// 1. No field is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer::config::file::repos_section::RepoEntryBuilder;
+    ///
+    /// let target = RepoTargetEntryBuilder::new().build();
+    /// let repo_builder = RepoEntryBuilder::new("vim");
+    ///     .branch("master")
+    ///     .remote("origin")
+    ///     .url("https://github.com/awkless/vim.git")
+    ///     .target(target)
+    ///     .build();
+    /// ```
+    pub fn build(self) -> RepoEntry {
+        trace!("Build new repository entry definition");
+        debug_assert_ne!(self.name, String::default(), "Name of repository entry is empty");
+        debug_assert_ne!(self.branch, String::default(), "Branch of repository entry is empty");
+        debug_assert_ne!(self.remote, String::default(), "Remote of repository entry is empty");
+        debug_assert_ne!(self.url, String::default(), "URL of repository entry is empty");
+        debug_assert_ne!(self.target, RepoTargetEntry::default(), "Target of repository is empty");
+
+        RepoEntry {
+            name: self.name,
+            branch: self.branch,
+            remote: self.remote,
+            url: self.url,
+            target: self.target,
+        }
+    }
+}
+
+#[derive(Debug, Default, Eq, PartialEq)]
 pub struct RepoTargetEntry {
     /// Repository will use the user's home directory as the main working tree.
     pub home: bool,

--- a/src/config/file/repos_section.rs
+++ b/src/config/file/repos_section.rs
@@ -89,6 +89,55 @@ impl RepoEntry {
         RepoEntryBuilder::new(name)
     }
 
+    /// Serialize repository entry definition into a TOML item.
+    ///
+    /// # Preconditions
+    ///
+    /// None.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Return serialized repository entry into TOML document format.
+    ///
+    /// # Invariants
+    ///
+    /// None.
+    ///
+    /// # Side Effects
+    ///
+    /// None.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use anyhow::Result;
+    /// # fn main() -> Result<()> {
+    /// use toml_edit::DocumentMut;
+    ///
+    /// use ricer::config::file::repos_section::{RepoEntry, RepoTargetEntry, TargetOsOption};
+    ///
+    /// let target_entry = RepoTargetEntry::builder()
+    ///    .home(true)
+    ///     .os(TargetOsOption::Windows)
+    ///     .user(Some("awkless"))
+    ///     .hostname(Some("lovelace"))
+    ///     .build();
+    /// let repo_entry = RepoEntry::builder("test")
+    ///     .branch("master")
+    ///     .remote("upstream")
+    ///     .url("https://github.com/awkless/foobar.git")
+    ///     .target(target_entry)
+    ///     .build();
+    /// let (key, value) = repo_entry.to_toml();
+    ///
+    /// let mut toml_doc: DocumentMut = "[repos]".parse()?;
+    /// let repos_table = toml_doc.get_mut("repos").unwrap();
+    /// let repos_table = repos_table.as_table_mut().unwrap();
+    /// repos_table.insert(&key, value);
+    /// println!("{:#?}", repos_table.to_string());
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn to_toml(&self) -> (Key, Item) {
         let mut repo_data = Table::new();
         let mut target_data = InlineTable::new();

--- a/src/config/file/repos_section.rs
+++ b/src/config/file/repos_section.rs
@@ -31,9 +31,9 @@
 //! Ricer only bootstrap a repository for a specific user and host.
 
 use log::trace;
-use toml_edit::visit::{visit_table_like_kv, Visit};
-use toml_edit::{Item, Key, InlineTable, Table, Value};
 use std::fmt::{Display, Formatter, Result};
+use toml_edit::visit::{visit_table_like_kv, Visit};
+use toml_edit::{InlineTable, Item, Key, Table, Value};
 
 /// Repository entry definition implementation.
 ///
@@ -120,13 +120,11 @@ impl<'toml> From<(&'toml Key, &'toml Item)> for RepoEntry {
         let (key, value) = toml_entry;
         let mut target_entry = RepoTargetEntry::builder();
         let mut repo_entry = RepoEntry::builder(key.get());
-
         target_entry.visit_item(value);
-        let target = target_entry.build();
-
         repo_entry.visit_item(value);
-        let repo = repo_entry.target(target).build();
-        repo
+
+        let target = target_entry.build();
+        repo_entry.target(target).build()
     }
 }
 
@@ -566,7 +564,7 @@ impl From<&str> for TargetOsOption {
             "unix" => Self::Unix,
             "macos" => Self::MacOs,
             "windows" => Self::Windows,
-            &_ =>  Self::Any,
+            &_ => Self::Any,
         }
     }
 }

--- a/src/config/file/repos_section.rs
+++ b/src/config/file/repos_section.rs
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
+
+//! Manage repository section definitions.
+//!
+//! The repository section of Ricer's configuration file houses all repository
+//! definitions that Ricer needs to keep track of. This section is defined in
+//! the following manner:
+//!
+//! ```markdown
+//! [repos.repo_name]
+//! branch = "master"
+//! remote = "origin"
+//! url = "https://github.com/awkless/vim.git"
+//! target = { home = true, os = "all", user = "awkless", hostname = "lovelace" }
+//! ```
+//!
+//! The `repo_name` field is the name of the repository entry. The `branch`
+//! field is the main branch that will be used for pulls, pushes, etc. The
+//! `remote` field is the main remote that will be used for pulls, pushes, etc.
+//! The `url` field is the URL used to clone, and push to the remote repository.
+//! Finally, the `target` field is used to configure when and where the
+//! repository entry should be cloned, pulled, pushed, etc. The `target` field
+//! is mainly used for bootstrapping purposes.
+//!
+//! In the `target` field, the `home` field determines if Ricer should make the
+//! repository entry use the user's home directory as the primary working tree.
+//! The `os` field makes Ricer boostrap the repository if and only if the user
+//! is using a specific operating system. Current values for `os` is _unix_,
+//! _macos_, _windows_, or _any_. The `user` and `hostname` fields will make
+//! Ricer only bootstrap a repository for a specific user and host.
+
+pub struct RepoEntry {
+    /// Name of repository. Also used to name the cloned repository in the
+    /// `repos` directory.
+    pub name: String,
+
+    /// Primary branch to use for Ricer's command set.
+    pub branch: String,
+
+    /// Primary remote to use for Ricer's command set.
+    pub remote: String,
+
+    /// Primary URL used to clone, push, and pull repository from.
+    pub url: String,
+
+    /// Bootstrapping options.
+    pub target: RepoTargetEntry,
+}
+
+pub struct RepoTargetEntry {
+    /// Repository will use the user's home directory as the main working tree.
+    pub home: bool,
+
+    /// Bootstrap repository if and only if user's is using a specific operating
+    /// system.
+    pub os: String,
+
+    /// Bootstrap repository for a specific user only on the system.
+    pub user: String,
+
+    /// Bootstrap repository for a specific host only on the system.
+    pub hostname: String,
+}

--- a/src/config/file/repos_section.rs
+++ b/src/config/file/repos_section.rs
@@ -31,6 +31,8 @@
 //! Ricer only bootstrap a repository for a specific user and host.
 
 use log::trace;
+use toml_edit::visit::{visit_table_like_kv, Visit};
+use toml_edit::{Item, Key};
 
 /// Repository entry definition implementation.
 ///
@@ -84,6 +86,21 @@ impl RepoEntry {
     /// ```
     pub fn builder(name: impl AsRef<str>) -> RepoEntryBuilder {
         RepoEntryBuilder::new(name)
+    }
+}
+
+impl<'toml> From<(&'toml Key, &'toml Item)> for RepoEntry {
+    fn from(toml_entry: (&'toml Key, &'toml Item)) -> Self {
+        let (key, value) = toml_entry;
+        let mut target_entry = RepoTargetEntry::builder();
+        let mut repo_entry = RepoEntry::builder(key.get());
+
+        target_entry.visit_item(value);
+        let target = target_entry.build();
+
+        repo_entry.visit_item(value);
+        let repo = repo_entry.target(target).build();
+        repo
     }
 }
 
@@ -275,6 +292,19 @@ impl RepoEntryBuilder {
     }
 }
 
+impl<'toml> Visit<'toml> for RepoEntryBuilder {
+    fn visit_table_like_kv(&mut self, key: &'toml str, node: &'toml Item) {
+        match key {
+            "branch" => self.branch = node.as_str().unwrap_or_default().to_string(),
+            "remote" => self.remote = node.as_str().unwrap_or_default().to_string(),
+            "url" => self.url = node.as_str().unwrap_or_default().to_string(),
+            &_ => visit_table_like_kv(self, key, node),
+        }
+
+        visit_table_like_kv(self, key, node);
+    }
+}
+
 /// Target bootstrap options for repository definition implementation.
 ///
 /// # Invariants
@@ -299,6 +329,20 @@ pub struct RepoTargetEntry {
 impl RepoTargetEntry {
     pub fn builder() -> RepoTargetEntryBuilder {
         RepoTargetEntryBuilder::new()
+    }
+}
+
+impl<'toml> Visit<'toml> for RepoTargetEntryBuilder {
+    fn visit_table_like_kv(&mut self, key: &'toml str, node: &'toml Item) {
+        match key {
+            "home" => self.home = *node.as_bool().get_or_insert(false),
+            "os" => self.os = TargetOsOption::from(node.as_str().unwrap_or_default()),
+            "user" => self.user = node.as_str().map(|str| str.to_string()),
+            "hostname" => self.hostname = node.as_str().map(|str| str.to_string()),
+            &_ => visit_table_like_kv(self, key, node),
+        }
+
+        visit_table_like_kv(self, key, node);
     }
 }
 
@@ -468,12 +512,7 @@ impl RepoTargetEntryBuilder {
     pub fn build(self) -> RepoTargetEntry {
         trace!("Build new target entry for repository entry definition");
 
-        RepoTargetEntry {
-            home: self.home,
-            os: self.os,
-            user: self.user,
-            hostname: self.hostname,
-        }
+        RepoTargetEntry { home: self.home, os: self.os, user: self.user, hostname: self.hostname }
     }
 }
 
@@ -492,4 +531,16 @@ pub enum TargetOsOption {
 
     /// Only target Windows operating systems.
     Windows,
+}
+
+impl From<&str> for TargetOsOption {
+    fn from(data: &str) -> Self {
+        match data {
+            "any" => Self::Any,
+            "unix" => Self::Unix,
+            "macos" => Self::MacOs,
+            "windows" => Self::Windows,
+            &_ =>  Self::Any,
+        }
+    }
 }

--- a/src/config/file/repos_section.rs
+++ b/src/config/file/repos_section.rs
@@ -32,7 +32,8 @@
 
 use log::trace;
 use toml_edit::visit::{visit_table_like_kv, Visit};
-use toml_edit::{Item, Key};
+use toml_edit::{Item, Key, InlineTable, Table, Value};
+use std::fmt::{Display, Formatter, Result};
 
 /// Repository entry definition implementation.
 ///
@@ -86,6 +87,31 @@ impl RepoEntry {
     /// ```
     pub fn builder(name: impl AsRef<str>) -> RepoEntryBuilder {
         RepoEntryBuilder::new(name)
+    }
+
+    pub fn to_toml(&self) -> (Key, Item) {
+        let mut repo_data = Table::new();
+        let mut target_data = InlineTable::new();
+
+        repo_data.insert("branch", Item::Value(Value::from(&self.branch)));
+        repo_data.insert("remote", Item::Value(Value::from(&self.remote)));
+        repo_data.insert("url", Item::Value(Value::from(&self.url)));
+        target_data.insert("home", Value::from(self.target.home));
+        target_data.insert("os", Value::from(self.target.os.to_string()));
+
+        if let Some(user) = &self.target.user {
+            target_data.insert("user", Value::from(user));
+        }
+
+        if let Some(hostname) = &self.target.hostname {
+            target_data.insert("hostname", Value::from(hostname));
+        }
+
+        repo_data.insert("target", Item::Value(Value::InlineTable(target_data)));
+
+        let key = Key::new(&self.name);
+        let value = Item::Table(repo_data);
+        (key, value)
     }
 }
 
@@ -541,6 +567,17 @@ impl From<&str> for TargetOsOption {
             "macos" => Self::MacOs,
             "windows" => Self::Windows,
             &_ =>  Self::Any,
+        }
+    }
+}
+
+impl Display for TargetOsOption {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self {
+            TargetOsOption::Any => write!(f, "any"),
+            TargetOsOption::Unix => write!(f, "unix"),
+            TargetOsOption::MacOs => write!(f, "macos"),
+            TargetOsOption::Windows => write!(f, "windows"),
         }
     }
 }

--- a/src/config/file/repos_section.rs
+++ b/src/config/file/repos_section.rs
@@ -59,9 +59,21 @@ pub struct RepoEntry {
 impl RepoEntry {
     /// Build new repository entry definition.
     ///
+    /// # Preconditions
+    ///
+    /// None.
+    ///
     /// # Postconditions
     ///
     /// 1. Return [`RepoEntryBuilder`].
+    ///
+    /// # Invariants
+    ///
+    /// None.
+    ///
+    /// # Side Effects
+    ///
+    /// None.
     ///
     /// # Examples
     ///
@@ -95,15 +107,21 @@ pub struct RepoEntryBuilder {
 impl RepoEntryBuilder {
     /// Construct repository entry builder.
     ///
+    /// # Preconditions
+    ///
+    /// None.
+    ///
     /// # Postconditions
     ///
     /// 1. Return new instance of repository entry builder.
     ///
-    /// ```no_run
-    /// use ricer::config::file::repos_section::RepoEntryBuilder;
+    /// # Invariants
     ///
-    /// let repo_builder = RepoEntryBuilder::new("vim");
-    /// ```
+    /// 1. No field is empty.
+    ///
+    /// # Side Effects
+    ///
+    /// None.
     pub fn new(name: impl AsRef<str>) -> Self {
         Self {
             name: name.as_ref().to_string(),
@@ -114,27 +132,99 @@ impl RepoEntryBuilder {
         }
     }
 
+    /// Set branch field.
+    ///
+    /// # Preconditions
+    ///
+    /// None.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Set [`branch`] field.
+    ///
+    /// Invariants
+    ///
+    /// # Side Effects
+    ///
+    /// None.
+    ///
+    /// [`branch`]: #member.branch
     pub fn branch(mut self, branch: impl AsRef<str>) -> Self {
         self.branch = branch.as_ref().to_string();
         self
     }
 
+    /// Set remote field.
+    ///
+    /// # Preconditions
+    ///
+    /// None.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Set [`remote`] field.
+    ///
+    /// Invariants
+    ///
+    /// # Side Effects
+    ///
+    /// None.
+    ///
+    /// [`remote`]: #member.remote
     pub fn remote(mut self, remote: impl AsRef<str>) -> Self {
         self.remote = remote.as_ref().to_string();
         self
     }
 
+    /// Set URL field.
+    ///
+    /// # Preconditions
+    ///
+    /// None.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Set [`url`] field.
+    ///
+    /// Invariants
+    ///
+    /// # Side Effects
+    ///
+    /// None.
+    ///
+    /// [`url`]: #member.url
     pub fn url(mut self, url: impl AsRef<str>) -> Self {
         self.url = url.as_ref().to_string();
         self
     }
 
+    /// Set target field.
+    ///
+    /// # Preconditions
+    ///
+    /// None.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Set [`target`] field.
+    ///
+    /// Invariants
+    ///
+    /// # Side Effects
+    ///
+    /// None.
+    ///
+    /// [`target`]: #member.target
     pub fn target(mut self, target: RepoTargetEntry) -> Self {
         self.target = target;
         self
     }
 
     /// Build new [`RepoEntry`].
+    ///
+    /// # Preconditions
+    ///
+    /// None.
     ///
     /// # Postconditions
     ///
@@ -144,26 +234,36 @@ impl RepoEntryBuilder {
     ///
     /// 1. No field is empty.
     ///
+    /// # Side Effects
+    ///
+    /// None.
+    ///
     /// # Examples
     ///
     /// ```no_run
-    /// use ricer::config::file::repos_section::RepoEntryBuilder;
+    /// # use anyhow::Result;
+    /// # fn main() -> Result<()> {
+    /// use ricer::config::file::repos_section::{RepoEntryBuilder, RepoTargetEntry, TargetOsOption};
     ///
-    /// let target = RepoTargetEntryBuilder::new().build();
-    /// let repo_builder = RepoEntryBuilder::new("vim");
+    /// let target = RepoTargetEntry::builder()
+    ///     .home(true)
+    ///     .os(TargetOsOption::Unix)
+    ///     .build();
+    /// let builder = RepoEntryBuilder::new("vim")
     ///     .branch("master")
     ///     .remote("origin")
     ///     .url("https://github.com/awkless/vim.git")
     ///     .target(target)
     ///     .build();
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn build(self) -> RepoEntry {
         trace!("Build new repository entry definition");
-        debug_assert_ne!(self.name, String::default(), "Name of repository entry is empty");
-        debug_assert_ne!(self.branch, String::default(), "Branch of repository entry is empty");
-        debug_assert_ne!(self.remote, String::default(), "Remote of repository entry is empty");
-        debug_assert_ne!(self.url, String::default(), "URL of repository entry is empty");
-        debug_assert_ne!(self.target, RepoTargetEntry::default(), "Target of repository is empty");
+        debug_assert!(!self.name.is_empty(), "Name of repository entry is empty");
+        debug_assert!(!self.branch.is_empty(), "Branch of repository entry is empty");
+        debug_assert!(!self.remote.is_empty(), "Remote of repository entry is empty");
+        debug_assert!(!self.url.is_empty(), "URL of repository entry is empty");
 
         RepoEntry {
             name: self.name,
@@ -175,6 +275,11 @@ impl RepoEntryBuilder {
     }
 }
 
+/// Target bootstrap options for repository definition implementation.
+///
+/// # Invariants
+///
+/// 1. No field is empty.
 #[derive(Debug, Default, Eq, PartialEq)]
 pub struct RepoTargetEntry {
     /// Repository will use the user's home directory as the main working tree.
@@ -182,11 +287,209 @@ pub struct RepoTargetEntry {
 
     /// Bootstrap repository if and only if user's is using a specific operating
     /// system.
-    pub os: String,
+    pub os: TargetOsOption,
 
     /// Bootstrap repository for a specific user only on the system.
-    pub user: String,
+    pub user: Option<String>,
 
     /// Bootstrap repository for a specific host only on the system.
-    pub hostname: String,
+    pub hostname: Option<String>,
+}
+
+impl RepoTargetEntry {
+    pub fn builder() -> RepoTargetEntryBuilder {
+        RepoTargetEntryBuilder::new()
+    }
+}
+
+/// Builder for target bootstrap options for repository definition implementation.
+#[derive(Debug, Default, Eq, PartialEq)]
+pub struct RepoTargetEntryBuilder {
+    home: bool,
+    os: TargetOsOption,
+    user: Option<String>,
+    hostname: Option<String>,
+}
+
+impl RepoTargetEntryBuilder {
+    /// Construct new repository target entry builder.
+    ///
+    /// # Preconditions
+    ///
+    /// None.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Return new repository target entry builder.
+    ///
+    /// # Invariants
+    ///
+    /// None.
+    ///
+    /// # Side Effects
+    ///
+    /// None.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Set home target.
+    ///
+    /// # Preconditions
+    ///
+    /// None.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Set [`home`] field.
+    ///
+    /// # Invariants
+    ///
+    /// None.
+    ///
+    /// # Side Effects
+    ///
+    /// None.
+    ///
+    /// [`home`]: #member.home
+    pub fn home(mut self, home: bool) -> Self {
+        self.home = home;
+        self
+    }
+
+    /// Set OS target.
+    ///
+    /// # Preconditions
+    ///
+    /// None.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Set [`os`] field.
+    ///
+    /// # Invariants
+    ///
+    /// None.
+    ///
+    /// # Side Effects
+    ///
+    /// None.
+    ///
+    /// [`os`]: #member.os
+    pub fn os(mut self, os: TargetOsOption) -> Self {
+        self.os = os;
+        self
+    }
+
+    /// Set user target
+    ///
+    /// # Preconditions
+    ///
+    /// None.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Set [`user`] field.
+    ///
+    /// # Invariants
+    ///
+    /// None.
+    ///
+    /// # Side Effects
+    ///
+    /// None.
+    ///
+    /// [`user`]: #member.user
+    pub fn user(mut self, user: Option<impl AsRef<str>>) -> Self {
+        self.user = user.map(|str| str.as_ref().to_string());
+        self
+    }
+
+    /// Set hostname target.
+    ///
+    /// # Preconditions
+    ///
+    /// None.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Set [`hostname`] field.
+    ///
+    /// # Invariants
+    ///
+    /// None.
+    ///
+    /// # Side Effects
+    ///
+    /// None.
+    ///
+    /// [`hostname`]: #member.hostname
+    pub fn hostname(mut self, hostname: Option<impl AsRef<str>>) -> Self {
+        self.hostname = hostname.map(|str| str.as_ref().to_string());
+        self
+    }
+
+    /// Build new [`RepoTargetEntry`].
+    ///
+    /// # Preconditions
+    ///
+    /// None.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Return new [`RepoTargetEntry`].
+    ///
+    /// # Invariants
+    ///
+    /// None.
+    ///
+    /// # Side Effects
+    ///
+    /// None.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use anyhow::Result;
+    /// # fn main() -> Result<()> {
+    /// use ricer::config::file::repos_section::{RepoTargetEntryBuilder, TargetOsOption};
+    ///
+    /// let builder = RepoTargetEntryBuilder::new()
+    ///     .home(true)
+    ///     .os(TargetOsOption::Unix)
+    ///     .user(Some("awkless"))
+    ///     .hostname(Some("lovelace"))
+    ///     .build();
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`os`]: #member.os
+    pub fn build(self) -> RepoTargetEntry {
+        trace!("Build new target entry for repository entry definition");
+
+        RepoTargetEntry {
+            home: self.home,
+            os: self.os,
+            user: self.user,
+            hostname: self.hostname,
+        }
+    }
+}
+
+/// Target OS option types.
+#[derive(Debug, Default, Eq, PartialEq)]
+pub enum TargetOsOption {
+    /// Target any operating system.
+    #[default]
+    Any,
+
+    /// Only target Unix/Linux operating systems.
+    Unix,
+
+    /// Only target MacOs operating systems.
+    MacOs,
+
+    /// Only target Windows operating systems.
+    Windows,
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -6,3 +6,5 @@ mod locator;
 mod dir;
 
 mod cli;
+
+mod repos_section;

--- a/src/tests/repos_section.rs
+++ b/src/tests/repos_section.rs
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
+
+use rstest::{fixture, rstest};
+use pretty_assertions::assert_eq;
+use toml_edit::DocumentMut;
+
+use crate::config::file::repos_section::*;
+
+#[fixture]
+fn toml_doc_fixture() -> DocumentMut {
+    let toml = r#"
+    [repos.full_entry]
+    branch = "master"
+    remote = "origin"
+    url = "https://github.com/awkless/foobar.git"
+    target = { home = true, os = "unix", user = "awkless", hostname = "lovelace" }
+
+    [repos.no_target_entry]
+    branch = "master"
+    remote = "origin"
+    url = "https://github.com/awkless/foobar.git"
+    "#;
+
+    let toml_doc: DocumentMut = toml.parse().expect("Failed to parse toml data");
+    toml_doc
+}
+
+#[rstest]
+fn deserialize_full_repo_entry(toml_doc_fixture: DocumentMut) {
+    let repos_table = toml_doc_fixture.get("repos").expect("The 'repos' section does not exist");
+    let repos_table = repos_table.as_table().expect("The 'repos' section is not a table");
+    let repo_entry = repos_table.get_key_value("full_entry").expect("Full entry fixture does not exist");
+
+    let result = RepoEntry::from(repo_entry);
+    let target = RepoTargetEntry::builder()
+        .home(true)
+        .os(TargetOsOption::Unix)
+        .user(Some("awkless"))
+        .hostname(Some("lovelace"))
+        .build();
+    let expect = RepoEntry::builder("full_entry")
+        .branch("master")
+        .remote("origin")
+        .url("https://github.com/awkless/foobar.git")
+        .target(target)
+        .build();
+    assert_eq!(expect, result);
+}
+
+#[rstest]
+fn deserialize_repo_entry_with_missing_target_entry(toml_doc_fixture: DocumentMut) {
+    let repos_table = toml_doc_fixture.get("repos").expect("The 'repos' section does not exist");
+    let repos_table = repos_table.as_table().expect("The 'repos' section is not a table");
+    let repo_entry = repos_table.get_key_value("no_target_entry").expect("No target fixture does not exist");
+
+    let result = RepoEntry::from(repo_entry);
+    let target = RepoTargetEntry::default();
+    let expect = RepoEntry::builder("no_target_entry")
+        .branch("master")
+        .remote("origin")
+        .url("https://github.com/awkless/foobar.git")
+        .target(target)
+        .build();
+    assert_eq!(expect, result);
+}

--- a/src/tests/repos_section.rs
+++ b/src/tests/repos_section.rs
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
 
-use rstest::{fixture, rstest};
-use pretty_assertions::assert_eq;
-use toml_edit::DocumentMut;
 use indoc::indoc;
+use pretty_assertions::assert_eq;
+use rstest::{fixture, rstest};
+use toml_edit::DocumentMut;
 
 use crate::config::file::repos_section::*;
 
@@ -32,7 +32,8 @@ fn toml_doc_fixture() -> DocumentMut {
 fn deserialize_full_repo_entry(toml_doc_fixture: DocumentMut) {
     let repos_table = toml_doc_fixture.get("repos").expect("The 'repos' section does not exist");
     let repos_table = repos_table.as_table().expect("The 'repos' section is not a table");
-    let repo_entry = repos_table.get_key_value("full_entry").expect("Full entry fixture does not exist");
+    let repo_entry =
+        repos_table.get_key_value("full_entry").expect("Full entry fixture does not exist");
 
     let result = RepoEntry::from(repo_entry);
     let target = RepoTargetEntry::builder()
@@ -54,7 +55,8 @@ fn deserialize_full_repo_entry(toml_doc_fixture: DocumentMut) {
 fn deserialize_repo_entry_with_missing_target_entry(toml_doc_fixture: DocumentMut) {
     let repos_table = toml_doc_fixture.get("repos").expect("The 'repos' section does not exist");
     let repos_table = repos_table.as_table().expect("The 'repos' section is not a table");
-    let repo_entry = repos_table.get_key_value("no_target_entry").expect("No target fixture does not exist");
+    let repo_entry =
+        repos_table.get_key_value("no_target_entry").expect("No target fixture does not exist");
 
     let result = RepoEntry::from(repo_entry);
     let target = RepoTargetEntry::default();

--- a/src/tests/repos_section.rs
+++ b/src/tests/repos_section.rs
@@ -4,23 +4,25 @@
 use rstest::{fixture, rstest};
 use pretty_assertions::assert_eq;
 use toml_edit::DocumentMut;
+use indoc::indoc;
 
 use crate::config::file::repos_section::*;
 
 #[fixture]
 fn toml_doc_fixture() -> DocumentMut {
-    let toml = r#"
-    [repos.full_entry]
-    branch = "master"
-    remote = "origin"
-    url = "https://github.com/awkless/foobar.git"
-    target = { home = true, os = "unix", user = "awkless", hostname = "lovelace" }
+    let toml = indoc! {r#"
+        [repos.full_entry]
+        branch = "master"
+        remote = "origin"
+        url = "https://github.com/awkless/foobar.git"
+        target = { home = true, os = "unix", user = "awkless", hostname = "lovelace" }
 
-    [repos.no_target_entry]
-    branch = "master"
-    remote = "origin"
-    url = "https://github.com/awkless/foobar.git"
-    "#;
+        [repos.no_target_entry]
+        branch = "master"
+        remote = "origin"
+        url = "https://github.com/awkless/foobar.git"
+        "#
+    };
 
     let toml_doc: DocumentMut = toml.parse().expect("Failed to parse toml data");
     toml_doc
@@ -62,5 +64,47 @@ fn deserialize_repo_entry_with_missing_target_entry(toml_doc_fixture: DocumentMu
         .url("https://github.com/awkless/foobar.git")
         .target(target)
         .build();
+    assert_eq!(expect, result);
+}
+
+#[rstest]
+fn serialize_repo_entry_correctly(mut toml_doc_fixture: DocumentMut) {
+    let target_entry = RepoTargetEntry::builder()
+        .home(true)
+        .os(TargetOsOption::Windows)
+        .user(Some("awkless"))
+        .hostname(Some("lovelace"))
+        .build();
+    let repo_entry = RepoEntry::builder("test")
+        .branch("master")
+        .remote("upstream")
+        .url("https://github.com/awkless/foobar.git")
+        .target(target_entry)
+        .build();
+    let (key, value) = repo_entry.to_toml();
+    let repos_table = toml_doc_fixture.get_mut("repos").expect("The 'repos' table does not exist");
+    let repos_table = repos_table.as_table_mut().expect("Cannot convert 'repos' to table");
+    repos_table.insert(&key, value);
+
+    let result = toml_doc_fixture.to_string();
+    let expect = indoc! {r#"
+        [repos.full_entry]
+        branch = "master"
+        remote = "origin"
+        url = "https://github.com/awkless/foobar.git"
+        target = { home = true, os = "unix", user = "awkless", hostname = "lovelace" }
+
+        [repos.no_target_entry]
+        branch = "master"
+        remote = "origin"
+        url = "https://github.com/awkless/foobar.git"
+
+        [repos.test]
+        branch = "master"
+        remote = "upstream"
+        url = "https://github.com/awkless/foobar.git"
+        target = { home = true, os = "windows", user = "awkless", hostname = "lovelace" }
+        "#
+    };
     assert_eq!(expect, result);
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

Implement code to serialize and deserialize data from the `repos` section of Ricer's configuration file.

## Area of Effect

- Module `repos_section`.

## Tasks

- [x] Setup builder pattern to build repository entry definitions.
- [x] Setup way to deserialize a toml item.
- [x] Setup way to serialize repository entry into toml.
