### PR TITLE
Add way to deserialize `hooks` section of configuration file

### DIFF
--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -14,8 +14,8 @@
 
 use std::path::Path;
 
-pub mod repos_section;
 pub mod hooks_section;
+pub mod repos_section;
 
 use crate::error::RicerResult;
 use repos_section::RepoEntry;

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -15,6 +15,7 @@
 use std::path::Path;
 
 pub mod repos_section;
+pub mod hooks_section;
 
 use crate::error::RicerResult;
 use repos_section::RepoEntry;

--- a/src/config/file/hooks_section.rs
+++ b/src/config/file/hooks_section.rs
@@ -21,6 +21,8 @@
 //! repository to execute the current hook entry on only.
 
 use log::trace;
+use toml_edit::visit::{visit_inline_table, Visit};
+use toml_edit::{InlineTable, Item, Key};
 
 /// Command hook entry definition implementation.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -29,7 +31,7 @@ pub struct CommandHookEntry {
     pub cmd: String,
 
     /// Array of hook entries to execute.
-    pub hooks: Vec<HookEntry>
+    pub hooks: Vec<HookEntry>,
 }
 
 impl CommandHookEntry {
@@ -95,6 +97,28 @@ impl CommandHookEntry {
     /// ```
     pub fn add_hook(&mut self, hook: HookEntry) {
         self.hooks.push(hook);
+    }
+}
+
+impl<'toml> From<(&'toml Key, &'toml Item)> for CommandHookEntry {
+    fn from(toml_entry: (&'toml Key, &'toml Item)) -> Self {
+        let (key, value) = toml_entry;
+        let mut entry = CommandHookEntry::new(key.get());
+        entry.visit_item(value);
+        entry
+    }
+}
+
+impl<'toml> Visit<'toml> for CommandHookEntry {
+    fn visit_inline_table(&mut self, node: &'toml InlineTable) {
+        let pre = if let Some(pre) = node.get("pre") { pre.as_str() } else { None };
+        let post = if let Some(post) = node.get("post") { post.as_str() } else { None };
+        let repo = if let Some(repo) = node.get("repo") { repo.as_str() } else { None };
+
+        let hook_entry = HookEntry::builder().pre(pre).post(post).repo(repo).build();
+        self.add_hook(hook_entry);
+
+        visit_inline_table(self, node);
     }
 }
 
@@ -182,8 +206,8 @@ impl HookEntryBuilder {
     /// None.
     ///
     /// [`pre`]: #member.pre
-    pub fn pre(mut self, script_name: impl AsRef<str>) -> Self {
-        self.pre = Some(script_name.as_ref().to_string());
+    pub fn pre(mut self, script_name: Option<impl AsRef<str>>) -> Self {
+        self.pre = script_name.map(|s| s.as_ref().to_string());
         self
     }
 
@@ -206,8 +230,8 @@ impl HookEntryBuilder {
     /// None.
     ///
     /// [`post`]: #member.post
-    pub fn post(mut self, script_name: impl AsRef<str>) -> Self {
-        self.post = Some(script_name.as_ref().to_string());
+    pub fn post(mut self, script_name: Option<impl AsRef<str>>) -> Self {
+        self.post = script_name.map(|s| s.as_ref().to_string());
         self
     }
 
@@ -230,8 +254,8 @@ impl HookEntryBuilder {
     /// None.
     ///
     /// [`repo`]: #member.repo
-    pub fn repo(mut self, repo_name: impl AsRef<str>) -> Self {
-        self.repo = Some(repo_name.as_ref().to_string());
+    pub fn repo(mut self, repo_name: Option<impl AsRef<str>>) -> Self {
+        self.repo = repo_name.map(|s| s.as_ref().to_string());
         self
     }
 
@@ -259,9 +283,9 @@ impl HookEntryBuilder {
     /// use ricer::config::file::hooks_section::HookEntry;
     ///
     /// let hook_entry = HookEntryBuilder::new()
-    ///     .pre("hook.sh")
-    ///     .post("hook.sh")
-    ///     .repo("vim")
+    ///     .pre(Some("hook.sh"))
+    ///     .post(Some("hook.sh"))
+    ///     .repo(Some("vim"))
     ///     .build();
     /// println!("{:#?}", hook_entry);
     /// ```

--- a/src/config/file/hooks_section.rs
+++ b/src/config/file/hooks_section.rs
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
+
+//! Manage command hook definitions.
+//!
+//! A command hook definition in Ricer is stored in the `hooks` section of the
+//! configuration file. Currently, command hooks follow this general formatting:
+//!
+//! ```markdown
+//! [hooks]
+//! cmd = [
+//!     { pre = "hook.sh", post = "hook.sh", repo = "vim" }
+//!     ...
+//! ]
+//! ```
+//!
+//! The `cmd` field is the name of the Ricer command to bind the hook
+//! definitions too. The `pre` field is the hook script that will be executed
+//! _before_ the target command. The `post` field is the hook script that will
+//! be executed _after_ the target command. The `repo` command is the target
+//! repository to execute the current hook entry on only.
+
+/// Command hook entry definition implementation.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct CommandHookEntry {
+    /// Name of command to bind hook definition entries too.
+    pub cmd: String,
+
+    /// Array of hook entries to execute.
+    pub hooks: Vec<HookEntry>
+}
+
+/// Hook entry definition to be added into array of command hook definition.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct HookEntry {
+    /// Execute hook script _before_ command itself.
+    pub pre: Option<String>,
+
+    /// Execute hook script _after_ command itself.
+    pub post: Option<String>,
+
+    /// Execute hook script _only_ for a target repository definition.
+    pub repo: Option<String>,
+}

--- a/src/config/file/hooks_section.rs
+++ b/src/config/file/hooks_section.rs
@@ -61,7 +61,43 @@ impl CommandHookEntry {
     pub fn new(cmd_name: impl AsRef<str>) -> Self {
         Self { cmd: cmd_name.as_ref().to_string(), hooks: Default::default() }
     }
+
+    /// Add hook entry into command hook definition.
+    ///
+    /// # Preconditions
+    ///
+    /// None.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Add hook entry to [`hooks`] field.
+    ///
+    /// # Invariants
+    ///
+    /// None.
+    ///
+    /// # Side Effects
+    ///
+    /// None.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer::config::file::hooks_section::{CommandHookEntry, HookEntry};
+    ///
+    /// let mut cmd_hook = CommandHookEntry::new();
+    /// let hook_entry = HookEntry::builder()
+    ///     .pre("hook.sh")
+    ///     .post("hook.sh")
+    ///     .repo("vim")
+    ///     .build();
+    /// cmd_hook.add_hook(hook_entry);
+    /// ```
+    pub fn add_hook(&mut self, hook: HookEntry) {
+        self.hooks.push(hook);
+    }
 }
+
 /// Hook entry definition to be added into array of command hook definition.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct HookEntry {

--- a/src/config/file/hooks_section.rs
+++ b/src/config/file/hooks_section.rs
@@ -32,6 +32,36 @@ pub struct CommandHookEntry {
     pub hooks: Vec<HookEntry>
 }
 
+impl CommandHookEntry {
+    /// Construct new command hook entry definition.
+    ///
+    /// # Preconditions
+    ///
+    /// None.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Return valid instance of command hook entry handler.
+    ///
+    /// # Invariants
+    ///
+    /// None.
+    ///
+    /// # Side Effects
+    ///
+    /// None.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ricer::config::file::hooks_section::CommandHookEntry;
+    ///
+    /// let cmd_hook = CommandHookEntry::new();
+    /// ```
+    pub fn new(cmd_name: impl AsRef<str>) -> Self {
+        Self { cmd: cmd_name.as_ref().to_string(), hooks: Default::default() }
+    }
+}
 /// Hook entry definition to be added into array of command hook definition.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct HookEntry {

--- a/src/config/file/hooks_section.rs
+++ b/src/config/file/hooks_section.rs
@@ -20,6 +20,8 @@
 //! be executed _after_ the target command. The `repo` command is the target
 //! repository to execute the current hook entry on only.
 
+use log::trace;
+
 /// Command hook entry definition implementation.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct CommandHookEntry {
@@ -41,4 +43,164 @@ pub struct HookEntry {
 
     /// Execute hook script _only_ for a target repository definition.
     pub repo: Option<String>,
+}
+
+impl HookEntry {
+    /// Build a new hook entry definition.
+    ///
+    /// # Preconditions
+    ///
+    /// None.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Return hook entry builder instance.
+    ///
+    /// # Invariants
+    ///
+    /// None.
+    ///
+    /// # Side Effects
+    ///
+    /// None.
+    pub fn builder() -> HookEntryBuilder {
+        HookEntryBuilder::new()
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct HookEntryBuilder {
+    pre: Option<String>,
+    post: Option<String>,
+    repo: Option<String>,
+}
+
+impl HookEntryBuilder {
+    /// Construct new hook entry builder.
+    ///
+    /// # Preconditions
+    ///
+    /// None.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Return new instance of hook entry builder.
+    ///
+    /// # Invariants
+    ///
+    /// None.
+    ///
+    /// # Side Effects
+    ///
+    /// None.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Set pre-script to run _before_ target command.
+    ///
+    /// # Preconditions
+    ///
+    /// None.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Set [`pre`] field.
+    ///
+    /// # Invariants
+    ///
+    /// None.
+    ///
+    /// # Side Effects
+    ///
+    /// None.
+    ///
+    /// [`pre`]: #member.pre
+    pub fn pre(mut self, script_name: impl AsRef<str>) -> Self {
+        self.pre = Some(script_name.as_ref().to_string());
+        self
+    }
+
+    /// Set post-script to run _before_ target command.
+    ///
+    /// # postconditions
+    ///
+    /// None.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Set [`post`] field.
+    ///
+    /// # Invariants
+    ///
+    /// None.
+    ///
+    /// # Side Effects
+    ///
+    /// None.
+    ///
+    /// [`post`]: #member.post
+    pub fn post(mut self, script_name: impl AsRef<str>) -> Self {
+        self.post = Some(script_name.as_ref().to_string());
+        self
+    }
+
+    /// Set repo-script to run _before_ target command.
+    ///
+    /// # repoconditions
+    ///
+    /// None.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Set [`repo`] field.
+    ///
+    /// # Invariants
+    ///
+    /// None.
+    ///
+    /// # Side Effects
+    ///
+    /// None.
+    ///
+    /// [`repo`]: #member.repo
+    pub fn repo(mut self, repo_name: impl AsRef<str>) -> Self {
+        self.repo = Some(repo_name.as_ref().to_string());
+        self
+    }
+
+    /// Build new [`HookEntry`].
+    ///
+    /// # Preconditions
+    ///
+    /// None.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Return new instance of [`HookEntry`].
+    ///
+    /// # Invariants
+    ///
+    /// None.
+    ///
+    /// # Side Effects
+    ///
+    /// None.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer::config::file::hooks_section::HookEntry;
+    ///
+    /// let hook_entry = HookEntryBuilder::new()
+    ///     .pre("hook.sh")
+    ///     .post("hook.sh")
+    ///     .repo("vim")
+    ///     .build();
+    /// println!("{:#?}", hook_entry);
+    /// ```
+    pub fn build(self) -> HookEntry {
+        trace!("Build new hook entry definition");
+        HookEntry { pre: self.pre, post: self.post, repo: self.repo }
+    }
 }

--- a/src/config/file/hooks_section.rs
+++ b/src/config/file/hooks_section.rs
@@ -58,7 +58,7 @@ impl CommandHookEntry {
     /// ```
     /// use ricer::config::file::hooks_section::CommandHookEntry;
     ///
-    /// let cmd_hook = CommandHookEntry::new();
+    /// let cmd_hook = CommandHookEntry::new("commit");
     /// ```
     pub fn new(cmd_name: impl AsRef<str>) -> Self {
         Self { cmd: cmd_name.as_ref().to_string(), hooks: Default::default() }
@@ -87,11 +87,11 @@ impl CommandHookEntry {
     /// ```no_run
     /// use ricer::config::file::hooks_section::{CommandHookEntry, HookEntry};
     ///
-    /// let mut cmd_hook = CommandHookEntry::new();
+    /// let mut cmd_hook = CommandHookEntry::new("commit");
     /// let hook_entry = HookEntry::builder()
-    ///     .pre("hook.sh")
-    ///     .post("hook.sh")
-    ///     .repo("vim")
+    ///     .pre(Some("hook.sh"))
+    ///     .post(Some("hook.sh"))
+    ///     .repo(Some("vim"))
     ///     .build();
     /// cmd_hook.add_hook(hook_entry);
     /// ```
@@ -280,7 +280,7 @@ impl HookEntryBuilder {
     /// # Examples
     ///
     /// ```no_run
-    /// use ricer::config::file::hooks_section::HookEntry;
+    /// use ricer::config::file::hooks_section::HookEntryBuilder;
     ///
     /// let hook_entry = HookEntryBuilder::new()
     ///     .pre(Some("hook.sh"))

--- a/src/config/file/repos_section.rs
+++ b/src/config/file/repos_section.rs
@@ -518,7 +518,7 @@ impl RepoTargetEntryBuilder {
     ///
     /// [`user`]: #member.user
     pub fn user(mut self, user: Option<impl AsRef<str>>) -> Self {
-        self.user = user.map(|str| str.as_ref().to_string());
+        self.user = user.map(|s| s.as_ref().to_string());
         self
     }
 
@@ -542,7 +542,7 @@ impl RepoTargetEntryBuilder {
     ///
     /// [`hostname`]: #member.hostname
     pub fn hostname(mut self, hostname: Option<impl AsRef<str>>) -> Self {
-        self.hostname = hostname.map(|str| str.as_ref().to_string());
+        self.hostname = hostname.map(|s| s.as_ref().to_string());
         self
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -8,3 +8,5 @@ mod dir;
 mod cli;
 
 mod repos_section;
+
+mod hooks_section;

--- a/src/tests/hooks_section.rs
+++ b/src/tests/hooks_section.rs
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
+
+use rstest::{fixture, rstest};
+use toml_edit::DocumentMut;
+use indoc::indoc;
+use pretty_assertions::assert_eq;
+
+use crate::config::file::hooks_section::*;
+
+#[fixture]
+fn toml_doc_fixture() -> DocumentMut {
+    let toml = indoc! {r#"
+        [hooks]
+        commit = [
+            { pre = "hook.sh", post = "hook.sh", repo = "vim" },
+            { pre = "hook.sh", post = "hook.sh" },
+            { post = "hook.sh" }
+        ]
+        "#
+    };
+
+    let toml_doc: DocumentMut = toml.parse().expect("Failed to parse toml data");
+    toml_doc
+}
+
+#[rstest]
+fn deserialize_hook_entry_correctly(toml_doc_fixture: DocumentMut) {
+    let hooks_table = toml_doc_fixture.get("hooks").expect("Section 'hooks' does not exist");
+    let hooks_table = hooks_table.as_table().expect("Cannot convert 'hooks' into table");
+    let hook_entry = hooks_table.get_key_value("commit").expect("Commit command hook does not exist");
+
+    let result = CommandHookEntry::from(hook_entry);
+    let mut expect = CommandHookEntry::new("commit");
+    expect.add_hook(
+        HookEntry::builder()
+        .pre(Some("hook.sh"))
+        .post(Some("hook.sh"))
+        .repo(Some("vim"))
+        .build(),
+    );
+    expect.add_hook(HookEntry::builder().pre(Some("hook.sh")).post(Some("hook.sh")).build());
+    expect.add_hook(HookEntry::builder().post(Some("hook.sh")).build());
+    assert_eq!(expect, result);
+}

--- a/src/tests/hooks_section.rs
+++ b/src/tests/hooks_section.rs
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
 
-use rstest::{fixture, rstest};
-use toml_edit::DocumentMut;
 use indoc::indoc;
 use pretty_assertions::assert_eq;
+use rstest::{fixture, rstest};
+use toml_edit::DocumentMut;
 
 use crate::config::file::hooks_section::*;
 
@@ -28,16 +28,13 @@ fn toml_doc_fixture() -> DocumentMut {
 fn deserialize_hook_entry_correctly(toml_doc_fixture: DocumentMut) {
     let hooks_table = toml_doc_fixture.get("hooks").expect("Section 'hooks' does not exist");
     let hooks_table = hooks_table.as_table().expect("Cannot convert 'hooks' into table");
-    let hook_entry = hooks_table.get_key_value("commit").expect("Commit command hook does not exist");
+    let hook_entry =
+        hooks_table.get_key_value("commit").expect("Commit command hook does not exist");
 
     let result = CommandHookEntry::from(hook_entry);
     let mut expect = CommandHookEntry::new("commit");
     expect.add_hook(
-        HookEntry::builder()
-        .pre(Some("hook.sh"))
-        .post(Some("hook.sh"))
-        .repo(Some("vim"))
-        .build(),
+        HookEntry::builder().pre(Some("hook.sh")).post(Some("hook.sh")).repo(Some("vim")).build(),
     );
     expect.add_hook(HookEntry::builder().pre(Some("hook.sh")).post(Some("hook.sh")).build());
     expect.add_hook(HookEntry::builder().post(Some("hook.sh")).build());


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

This pull request implements a way to deserialize a command hook definition entry from Ricer's configuration file.

What do your changes do?

## Area of Effect

- Module `ricer::config::file::hooks_section`.
