### PR TITLE
Implement default configuration file manager

### DIFF
--- a/crates/ricer_test_tools/src/fakes.rs
+++ b/crates/ricer_test_tools/src/fakes.rs
@@ -36,7 +36,7 @@ impl FakeConfigDir {
         FakeConfigDirBuilder::new()
     }
 
-    /// Get stored path to target fake configuration file at top-level.
+    /// Get stored stub to target fake configuration file at top-level.
     ///
     /// # Errors
     ///
@@ -45,13 +45,13 @@ impl FakeConfigDir {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// use ricer_test_tools::fakes::FakeConfigDir;
     ///
     /// let config = FakeConfigDir::builder()
     ///     .config_file("sample config data")
     ///     .build();
-    /// let path = config.config_file_stub();
+    /// let stub = config.config_file_stub();
     /// ```
     pub fn config_file_stub(&self) -> &FileStub {
         match self.file_stubs.get(&self.root_dir.join("config.toml")) {
@@ -60,7 +60,31 @@ impl FakeConfigDir {
         }
     }
 
-    /// Get stored path to target fake ignore file in 'ignores' directory.
+    /// Get stored mutable stub to target fake configuration file at top-level.
+    ///
+    /// # Errors
+    ///
+    /// Panics if ignore file is not being tracked by fake configuration
+    /// directory.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer_test_tools::fakes::FakeConfigDir;
+    ///
+    /// let config = FakeConfigDir::builder()
+    ///     .config_file("sample config data")
+    ///     .build();
+    /// let stub = config.config_file_stub_mut();
+    /// ```
+    pub fn config_file_stub_mut(&mut self) -> &mut FileStub {
+        match self.file_stubs.get_mut(&self.root_dir.join("config.toml")) {
+            Some(file) => file,
+            None => panic!("Configuration file is not being tracked by fake directory"),
+        }
+    }
+
+    /// Get stored stub to target fake ignore file in 'ignores' directory.
     ///
     /// Ignore files in Ricer are named after repositories in the `repos`
     /// directory with a '.ignore' extension. However, not all repositories will
@@ -85,7 +109,7 @@ impl FakeConfigDir {
     /// let config = FakeConfigDir::builder()
     ///     .ignore_file("fake_ignore", "/*") // Stored as 'fake_ignore.ignore'
     ///     .build();
-    /// let path = config.ignore_file_stub("fake_ignore");
+    /// let stub = config.ignore_file_stub("fake_ignore");
     /// ```
     pub fn ignore_file_stub(&self, repo: impl AsRef<Path>) -> &FileStub {
         let ignore_file = format!("{}.ignore", repo.as_ref().display());
@@ -95,7 +119,42 @@ impl FakeConfigDir {
         }
     }
 
-    /// Get path to stored hook script in fake 'hooks' directory.
+    /// Get stored mutable stub to target fake ignore file in 'ignores' directory.
+    ///
+    /// Ignore files in Ricer are named after repositories in the `repos`
+    /// directory with a '.ignore' extension. However, not all repositories will
+    /// have a corresponding ignore file. Usually, repositories without ignore
+    /// files are ones who do not target the user's home directory as their
+    /// working tree.
+    ///
+    /// Regardless, to get an absolute path to fake ignore file, the caller
+    /// just needs to provide the name of the file without the `.ignore`
+    /// extension.
+    ///
+    /// # Errors
+    ///
+    /// Panics if ignore file is not being tracked by fake configuration
+    /// directory.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ricer_test_tools::fakes::FakeConfigDir;
+    ///
+    /// let config = FakeConfigDir::builder()
+    ///     .ignore_file("fake_ignore", "/*") // Stored as 'fake_ignore.ignore'
+    ///     .build();
+    /// let stub = config.ignore_file_stub_mut("fake_ignore");
+    /// ```
+    pub fn ignore_file_stub_mut(&mut self, repo: impl AsRef<Path>) -> &mut FileStub {
+        let ignore_file = format!("{}.ignore", repo.as_ref().display());
+        match self.file_stubs.get_mut(&self.ignores_dir.join(&ignore_file)) {
+            Some(file) => file,
+            None => panic!("Ignore file '{}' is not being tracked by fake directory", &ignore_file),
+        }
+    }
+
+    /// Get stub to stored hook script in fake 'hooks' directory.
     ///
     /// Caller needs to provide full filename of hook to obtain its path.
     ///
@@ -112,7 +171,7 @@ impl FakeConfigDir {
     /// let config = FakeConfigDir::builder()
     ///     .hook_script("hook.sh", "chmod +x blah")
     ///     .build();
-    /// let path = config.hook_script_stub("hook.sh");
+    /// let stub = config.hook_script_stub("hook.sh");
     /// ```
     pub fn hook_script_stub(&self, name: impl AsRef<Path>) -> &FileStub {
         match self.file_stubs.get(&self.hooks_dir.join(name.as_ref())) {
@@ -124,7 +183,36 @@ impl FakeConfigDir {
         }
     }
 
-    /// Get path to stored Git repository in fake 'repos' directory.
+    /// Get mutable stub to stored hook script in fake 'hooks' directory.
+    ///
+    /// Caller needs to provide full filename of hook to obtain its path.
+    ///
+    /// # Errors
+    ///
+    /// Panics if named hook script is not being tracked by fake configuration
+    /// directory.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ricer_test_tools::fakes::FakeConfigDir;
+    ///
+    /// let config = FakeConfigDir::builder()
+    ///     .hook_script("hook.sh", "chmod +x blah")
+    ///     .build();
+    /// let stub = config.hook_script_stub_mut("hook.sh");
+    /// ```
+    pub fn hook_script_stub_mut(&mut self, name: impl AsRef<Path>) -> &mut FileStub {
+        match self.file_stubs.get_mut(&self.hooks_dir.join(name.as_ref())) {
+            Some(file) => file,
+            None => panic!(
+                "Hook script '{}' is not being tracked by fake directory",
+                &name.as_ref().display()
+            ),
+        }
+    }
+
+    /// Get stub to stored Git repository in fake 'repos' directory.
     ///
     /// Caller needs to provide full filename of hook to obtain its path.
     ///
@@ -141,11 +229,38 @@ impl FakeConfigDir {
     /// let config = FakeConfigDir::builder()
     ///     .git_repo("fake_repo")
     ///     .build();
-    /// let path = config.hook_script_stub("hook.sh");
+    /// let stub = config.hook_script_stub("hook.sh");
     /// ```
     pub fn git_repo_stub(&self, name: impl AsRef<Path>) -> &GitRepoStub {
         let git_repo = format!("{}.git", name.as_ref().display());
         match self.repo_stubs.get(&self.repos_dir.join(&git_repo)) {
+            Some(repo) => repo,
+            None => panic!("Repository '{}' is not being tracked by fake directory", &git_repo),
+        }
+    }
+
+    /// Get mutable stub to stored Git repository in fake 'repos' directory.
+    ///
+    /// Caller needs to provide full filename of hook to obtain its path.
+    ///
+    /// # Errors
+    ///
+    /// Panics if named Git repository is not being tracked by fake configuration
+    /// directory.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer_test_tools::fakes::FakeConfigDir;
+    ///
+    /// let config = FakeConfigDir::builder()
+    ///     .git_repo("fake_repo")
+    ///     .build();
+    /// let stub = config.hook_script_stub_mut("hook.sh");
+    /// ```
+    pub fn git_repo_stub_mut(&mut self, name: impl AsRef<Path>) -> &mut GitRepoStub {
+        let git_repo = format!("{}.git", name.as_ref().display());
+        match self.repo_stubs.get_mut(&self.repos_dir.join(&git_repo)) {
             Some(repo) => repo,
             None => panic!("Repository '{}' is not being tracked by fake directory", &git_repo),
         }

--- a/src/config/dir.rs
+++ b/src/config/dir.rs
@@ -111,10 +111,6 @@ impl DefaultConfigDirManager {
     ///
     /// 1. All stored paths must be absolute.
     ///
-    /// # Side Effects
-    ///
-    /// None.
-    ///
     /// # Examples
     ///
     /// ```no_run
@@ -162,13 +158,9 @@ impl ConfigDirManager for DefaultConfigDirManager {
     ///
     /// 1. Path returned is guaranteed to be absolute.
     ///
-    /// # Side Effects
-    ///
-    /// None.
-    ///
     /// # Errors
     ///
-    /// 1. Returns `RicerError::Unrecoverable` if configuration file does not
+    /// 1. Returns [`RicerError::Unrecoverable`] if configuration file does not
     ///    exist at `$XDG_CONFIG_HOME/ricer/config.toml`.
     ///
     /// # Examples
@@ -215,10 +207,6 @@ impl ConfigDirManager for DefaultConfigDirManager {
     /// # Invariants
     ///
     /// 1. Path returned is guaranteed to be absolute.
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     ///
     /// # Errors
     ///
@@ -270,10 +258,6 @@ impl ConfigDirManager for DefaultConfigDirManager {
     ///
     /// 1. Path returned is guaranteed to be absolute.
     ///
-    /// # Side Effects
-    ///
-    /// None.
-    ///
     /// # Errors
     ///
     /// 1. Returns `RicerError::Unrecoverable` if hook script does not exist
@@ -324,10 +308,6 @@ impl ConfigDirManager for DefaultConfigDirManager {
     ///
     /// 1. Path returned is guaranteed to be absolute.
     ///
-    /// # Side Effects
-    ///
-    /// None.
-    ///
     /// # Errors
     ///
     /// 1. Returns `RicerError::Unrecoverable` if ignore file does not exist
@@ -366,10 +346,6 @@ impl ConfigDirManager for DefaultConfigDirManager {
 
     /// Get path to root of configuration directory.
     ///
-    /// # Preconditions
-    ///
-    /// None.
-    ///
     /// # Postconditions
     ///
     /// 1. Return path to root of configuration directory.
@@ -377,19 +353,11 @@ impl ConfigDirManager for DefaultConfigDirManager {
     /// # Invariants
     ///
     /// 1. Path returned is guaranteed to be absolute.
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     fn root_dir(&self) -> &Path {
         self.root_dir.as_path()
     }
 
     /// Get path to `repos` sub-directory in configuration directory.
-    ///
-    /// # Preconditions
-    ///
-    /// None.
     ///
     /// # Postconditions
     ///
@@ -398,19 +366,11 @@ impl ConfigDirManager for DefaultConfigDirManager {
     /// # Invariants
     ///
     /// 1. Path returned is guaranteed to be absolute.
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     fn repos_dir(&self) -> &Path {
         self.repos_dir.as_path()
     }
 
     /// Get path to `hooks` sub-directory in configuration directory.
-    ///
-    /// # Preconditions
-    ///
-    /// None.
     ///
     /// # Postconditions
     ///
@@ -419,19 +379,11 @@ impl ConfigDirManager for DefaultConfigDirManager {
     /// # Invariants
     ///
     /// 1. Path returned is guaranteed to be absolute.
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     fn hooks_dir(&self) -> &Path {
         self.hooks_dir.as_path()
     }
 
     /// Get path to `ignores` sub-directory in configuration directory.
-    ///
-    /// # Preconditions
-    ///
-    /// None.
     ///
     /// # Postconditions
     ///
@@ -440,10 +392,6 @@ impl ConfigDirManager for DefaultConfigDirManager {
     /// # Invariants
     ///
     /// 1. Path returned is guaranteed to be absolute.
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     fn ignores_dir(&self) -> &Path {
         self.ignores_dir.as_path()
     }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -16,7 +16,7 @@ use anyhow::anyhow;
 use log::debug;
 use std::fs::{read_to_string, write};
 use std::path::Path;
-use toml_edit::{DocumentMut, Item, Table};
+use toml_edit::{DocumentMut, Decor, Item, Table, Key};
 
 pub mod hooks_section;
 pub mod repos_section;
@@ -117,9 +117,10 @@ impl ConfigFileManager for DefaultConfigFileManager {
             ))?;
             repos_section.insert(repo_name.get(), repo_data);
         } else {
-            self.doc.insert("repos", Item::Table(Table::new()));
-            let repos = &mut self.doc["repos"];
-            repos.as_table_mut().unwrap().insert(repo_name.get(), repo_data);
+            let mut repo_section = Table::new();
+            repo_section.insert(repo_name.get(), repo_data);
+            repo_section.set_implicit(true);
+            self.doc.insert("repos", Item::Table(repo_section));
         }
 
         Ok(())

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -12,11 +12,10 @@
 //!
 //! [toml-spec]: https://toml.io/en/v1.0.0
 
-use anyhow::anyhow;
-use log::debug;
+use log::{debug, trace};
 use std::fs::{read_to_string, write};
 use std::path::Path;
-use toml_edit::{Decor, DocumentMut, Item, Key, Table};
+use toml_edit::{DocumentMut, Item, Table};
 
 pub mod hooks_section;
 pub mod repos_section;
@@ -105,6 +104,7 @@ impl ConfigFileManager for DefaultConfigFileManager {
 
     /// Deserialize repository entry from parsed configuration file data.
     fn get_repo(&self, repo_name: impl AsRef<str>) -> RicerResult<RepoEntry> {
+        debug!("Get repository definition '{}' from configuration file", repo_name.as_ref());
         let repo_toml = self.doc.get("repos").ok_or(RicerError::NoReposSection)?;
         let repo_toml = repo_toml.as_table().ok_or(RicerError::ReposSectionNotTable)?;
         let repo_toml = repo_toml
@@ -115,16 +115,19 @@ impl ConfigFileManager for DefaultConfigFileManager {
 
     /// Serialize repository entry into parsed configuration file data.
     fn add_repo(&mut self, repo_entry: &RepoEntry) -> RicerResult<()> {
+        debug!("Add repository definition '{}' too configuration file", &repo_entry.name);
         let (repo_name, repo_data) = repo_entry.to_toml();
-        if let Some(repos_section) = self.doc.get_mut("repos") {
-            let repos_section =
-                repos_section.as_table_mut().ok_or(RicerError::ReposSectionNotTable)?;
-            repos_section.insert(repo_name.get(), repo_data);
+        if let Some(repos) = self.doc.get_mut("repos") {
+            trace!("The 'repos' section exists, add to it");
+            let repos =
+                repos.as_table_mut().ok_or(RicerError::ReposSectionNotTable)?;
+            repos.insert(repo_name.get(), repo_data);
         } else {
-            let mut repo_section = Table::new();
-            repo_section.insert(repo_name.get(), repo_data);
-            repo_section.set_implicit(true);
-            self.doc.insert("repos", Item::Table(repo_section));
+            trace!("The 'repos' section does not exist, set it up and add to it");
+            let mut repos = Table::new();
+            repos.insert(repo_name.get(), repo_data);
+            repos.set_implicit(true);
+            self.doc.insert("repos", Item::Table(repos));
         }
 
         Ok(())
@@ -132,7 +135,13 @@ impl ConfigFileManager for DefaultConfigFileManager {
 
     /// Remove repository entry from configuration file data.
     fn remove_repo(&mut self, repo_name: impl AsRef<str>) -> RicerResult<RepoEntry> {
-        todo!();
+        debug!("Remove repository definition '{}' from configuration file", repo_name.as_ref());
+        let repos = self.doc.get_mut("repos").ok_or(RicerError::NoReposSection)?;
+        let repos = repos.as_table_mut().ok_or(RicerError::ReposSectionNotTable)?;
+        let (repo_key, repo_data) = repos.remove_entry(repo_name.as_ref()).ok_or(
+            RicerError::NoRepoFound { repo_name: repo_name.as_ref().to_string() }
+        )?;
+        Ok(RepoEntry::from((&repo_key, &repo_data)))
     }
 
     /// Rename repository entry in configuration file data.

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -13,12 +13,14 @@
 //! [toml-spec]: https://toml.io/en/v1.0.0
 
 use std::path::Path;
+use toml_edit::DocumentMut;
 
 pub mod hooks_section;
 pub mod repos_section;
 
 use crate::error::RicerResult;
 use repos_section::RepoEntry;
+use hooks_section::CommandHookEntry;
 
 /// Configuration file manager representation.
 pub trait ConfigFileManager {
@@ -32,5 +34,63 @@ pub trait ConfigFileManager {
     fn data(&self) -> String;
 
     /// Deserialize repository entry from parsed configuration file data.
-    fn get_repo_entry(&self, repo_name: impl AsRef<str>) -> Option<RepoEntry>;
+    fn get_repo(&self, repo_name: impl AsRef<str>) -> RicerResult<RepoEntry>;
+
+    /// Serialize repository entry into parsed configuration file data.
+    fn add_repo(&mut self, repo_entry: &RepoEntry) -> RicerResult<()>;
+
+    /// Remove repository entry from configuration file data.
+    fn remove_repo(&mut self, repo_name: impl AsRef<str>) -> RicerResult<RepoEntry>;
+
+    /// Rename repository entry in configuration file data.
+    fn rename_repo(&mut self, from: impl AsRef<str>, to: impl AsRef<str>) -> RicerResult<()>;
+
+    /// Deserialize command hook envry from parsed configuration file data.
+    fn get_cmd_hook(&self, cmd_name: impl AsRef<str>) -> RicerResult<CommandHookEntry>;
+}
+
+pub struct DefaultConfigFileManager {
+    doc: DocumentMut,
+}
+
+impl ConfigFileManager for DefaultConfigFileManager {
+    /// Read from configuration file at provided path.
+    fn read(&mut self, path: impl AsRef<Path>) -> RicerResult<()> {
+        todo!();
+    }
+
+    /// Write to configuration file at provided path.
+    fn write(&mut self, path: impl AsRef<Path>) -> RicerResult<()> {
+        todo!();
+    }
+
+    /// Show current configuration file data in string form.
+    fn data(&self) -> String {
+        todo!();
+    }
+
+    /// Deserialize repository entry from parsed configuration file data.
+    fn get_repo(&self, repo_name: impl AsRef<str>) -> RicerResult<RepoEntry> {
+        todo!();
+    }
+
+    /// Serialize repository entry into parsed configuration file data.
+    fn add_repo(&mut self, repo_entry: &RepoEntry) -> RicerResult<()> {
+        todo!();
+    }
+
+    /// Remove repository entry from configuration file data.
+    fn remove_repo(&mut self, repo_name: impl AsRef<str>) -> RicerResult<RepoEntry> {
+        todo!();
+    }
+
+    /// Rename repository entry in configuration file data.
+    fn rename_repo(&mut self, from: impl AsRef<str>, to: impl AsRef<str>) -> RicerResult<()> {
+        todo!();
+    }
+
+    /// Deserialize command hook envry from parsed configuration file data.
+    fn get_cmd_hook(&self, cmd_name: impl AsRef<str>) -> RicerResult<CommandHookEntry> {
+        todo!();
+    }
 }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -15,7 +15,7 @@
 use log::{debug, trace};
 use std::fs::{read_to_string, write};
 use std::path::Path;
-use toml_edit::{DocumentMut, Item, Table};
+use toml_edit::{DocumentMut, Item, Key, Table};
 
 pub mod hooks_section;
 pub mod repos_section;
@@ -47,16 +47,34 @@ pub trait ConfigFileManager {
     /// Rename repository entry in configuration file data.
     fn rename_repo(&mut self, from: impl AsRef<str>, to: impl AsRef<str>) -> RicerResult<()>;
 
-    /// Deserialize command hook envry from parsed configuration file data.
+    /// Deserialize command hook entry from parsed configuration file data.
     fn get_cmd_hook(&self, cmd_name: impl AsRef<str>) -> RicerResult<CommandHookEntry>;
 }
 
+/// Default implementation of configuration file manager.
+///
+/// # Invariants
+///
+/// 1. Preserve original formatting and comments of user's configuration file.
 #[derive(Debug, Default)]
 pub struct DefaultConfigFileManager {
     doc: DocumentMut,
 }
 
 impl DefaultConfigFileManager {
+    /// Construct new default configuration file manager.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Obtain new valid instance of configuration file manager.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer::config::file::DefaultConfigFileManager;
+    ///
+    /// let cfg_file_mgr = DefaultConfigFileManager::new();
+    /// ```
     pub fn new() -> Self {
         Default::default()
     }
@@ -74,13 +92,25 @@ impl ConfigFileManager for DefaultConfigFileManager {
     ///
     /// 1. Parse TOML data for future manipulation.
     ///
-    /// # Invariants
+    /// # Errors
     ///
-    /// None.
+    /// 1. Returns [`RicerError::Unrecoverable`] if configuration file does not
+    ///    exist at provided path, or it contains invalid TOML formatting.
     ///
-    /// # Side Effects
+    /// # Examples
     ///
-    /// None.
+    /// ```no_run
+    /// # use anyhow::Result;
+    /// # fn main() -> Result<()> {
+    /// use ricer::config::file::{ConfigFileManager, DefaultConfigFileManager};
+    ///
+    /// let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    /// cfg_file_mgr.read("/path/to/config.toml")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`RicerError::Unrecoverable`]: crate::error::RicerError::Unrecoverable
     fn read(&mut self, path: impl AsRef<Path>) -> RicerResult<()> {
         debug!("Read configuration file from '{}'", path.as_ref().display());
         let buffer = read_to_string(path.as_ref())?;
@@ -90,6 +120,38 @@ impl ConfigFileManager for DefaultConfigFileManager {
     }
 
     /// Write to configuration file at provided path.
+    ///
+    /// # Preconditions
+    ///
+    /// 1. Full path to configuration file exists, i.e., no sub-directories are
+    ///    _not_ missing.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. If file does not exist, but all sub-directories do exist, then create
+    ///    it and write to it.
+    /// 2. Preserve original formatting and comments that existed before
+    ///    writing.
+    ///
+    /// # Errors
+    ///
+    /// 1. Return [`RicerError::Unrecoverable`] if sub-directories in provided
+    ///    path do not exist.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use anyhow::Result;
+    /// # fn main() -> Result<()> {
+    /// use ricer::config::file::{ConfigFileManager, DefaultConfigFileManager};
+    ///
+    /// let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    /// cfg_file_mgr.write("/path/to/config.toml")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`RicerError::Unrecoverable`]: crate::error::RicerError::Unrecoverable
     fn write(&mut self, path: impl AsRef<Path>) -> RicerResult<()> {
         debug!("Write configuration file to '{}'", path.as_ref().display());
         let buffer = self.doc.to_string();
@@ -98,11 +160,69 @@ impl ConfigFileManager for DefaultConfigFileManager {
     }
 
     /// Show current configuration file data in string form.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Return contents of parsed configuration file data in string form.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use anyhow::Result;
+    /// # fn main() -> Result<()> {
+    /// use ricer::config::file::{ConfigFileManager, DefaultConfigFileManager};
+    ///
+    /// let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    /// cfg_file_mgr.read("/path/to/config.toml")?;
+    /// println!("{}", cfg_file_mgr.to_string());
+    /// # Ok(())
+    /// # }
+    /// ```
     fn to_string(&self) -> String {
         self.doc.to_string()
     }
 
     /// Deserialize repository entry from parsed configuration file data.
+    ///
+    /// # Preconditions
+    ///
+    /// 1. The `repos` section exists.
+    /// 2. The `repos` section is defined as a table.
+    /// 3. Repository definition exists in `repos` section.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Return deserialized [`RepoEntry`].
+    /// 2. Will not modify configuration file data.
+    ///
+    /// # Errors
+    ///
+    /// 1. Return [`RicerError::NoReposSection`] if `repos` section does not
+    ///    exist.
+    /// 2. Return [`RicerError::ReposSectionNotTable`] if `repos` section is
+    ///    not defined as a table.
+    /// 3. Return [`RicerError::NoRepoFound`] if target repository definition
+    ///    does not exist.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use anyhow::Result;
+    /// # fn main() -> Result<()> {
+    /// use ricer::config::file::{ConfigFileManager, DefaultConfigFileManager};
+    ///
+    /// let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    /// cfg_file_mgr.read("/path/to/config.toml")?;
+    /// let repo = cfg_file_mgr.get_repo("vim")?;
+    /// println!("{:#?}", repo);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`RepoEntry`]: crate::config::file::repos_section::RepoEntry
+    /// [`RicerError::NoReposSection`]: crate::error::RicerError::NoReposSection
+    /// [`RicerError::ReposSectionNotTable`]: crate::error::RicerError::ReposSectionNotTable
+    /// [`RicerError::NoRepoFound`]: crate::error::RicerError::NoRepoFound
     fn get_repo(&self, repo_name: impl AsRef<str>) -> RicerResult<RepoEntry> {
         debug!("Get repository '{}' from configuration file", repo_name.as_ref());
         let repos = self.doc.get("repos").ok_or(RicerError::NoReposSection)?;
@@ -114,6 +234,48 @@ impl ConfigFileManager for DefaultConfigFileManager {
     }
 
     /// Serialize repository entry into parsed configuration file data.
+    ///
+    /// # Preconditions
+    ///
+    /// 1. The `repos` section is defined as a table.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Add repository definition into configuration file data.
+    ///     - Will add repository entry to existing `repos` section.
+    ///     - Will create `repos` section and add repository entry  if and only
+    ///       if `repos` section did not exist before.
+    ///
+    /// # Invariants
+    ///
+    /// 1. Preserve original comments and formatting that existed beforehand.
+    ///
+    /// # Errors
+    ///
+    /// 1. Return [`RicerError::ReposSectionNotTable`] if `repos` section is
+    ///    not defined as a table.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use anyhow::Result;
+    /// # fn main() -> Result<()> {
+    /// use ricer::config::file::{ConfigFileManager, DefaultConfigFileManager};
+    /// use ricer::config::file::repos_section::RepoEntry;
+    ///
+    /// let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    /// cfg_file_mgr.read("/path/to/config.toml")?;
+    /// let repo = RepoEntry::builder("vim")
+    ///     .branch("main")
+    ///     .remote("origin")
+    ///     .url("https://github.com/awkless/vim.git")
+    ///     .build();
+    /// cfg_file_mgr.add_repo(&repo)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`RicerError::ReposSectionNotTable`]: crate::error::RicerError::ReposSectionNotTable
     fn add_repo(&mut self, repo_entry: &RepoEntry) -> RicerResult<()> {
         debug!("Add repository '{}' too configuration file", &repo_entry.name);
         let (repo_name, repo_data) = repo_entry.to_toml();
@@ -133,6 +295,50 @@ impl ConfigFileManager for DefaultConfigFileManager {
     }
 
     /// Remove repository entry from configuration file data.
+    ///
+    /// # Preconditions
+    ///
+    /// 1. The `repos` section exists.
+    /// 2. The `repos` section is defined as a table.
+    /// 3. Repository definition exists in `repos` section.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Remove target repository definition from configuration file data.
+    /// 2. Return removed target repository definition as a [`RepoEntry`].
+    ///
+    /// # Invariants
+    ///
+    /// 1. Preserve original comments and formatting that existed beforehand.
+    ///
+    /// # Errors
+    ///
+    /// 1. Return [`RicerError::NoReposSection`] if `repos` section does not
+    ///    exist.
+    /// 2. Return [`RicerError::ReposSectionNotTable`] if `repos` section is
+    ///    not defined as a table.
+    /// 3. Return [`RicerError::NoRepoFound`] if target repository definition
+    ///    does not exist.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use anyhow::Result;
+    /// # fn main() -> Result<()> {
+    /// use ricer::config::file::{ConfigFileManager, DefaultConfigFileManager};
+    ///
+    /// let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    /// cfg_file_mgr.read("/path/to/config.toml")?;
+    /// let repo = cfg_file_mgr.remove_repo("vim")?;
+    /// println!("{:#?}", repo);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`RepoEntry`]: crate::config::file::repos_section::RepoEntry
+    /// [`RicerError::NoReposSection`]: crate::error::RicerError::NoReposSection
+    /// [`RicerError::ReposSectionNotTable`]: crate::error::RicerError::ReposSectionNotTable
+    /// [`RicerError::NoRepoFound`]: crate::error::RicerError::NoRepoFound
     fn remove_repo(&mut self, repo_name: impl AsRef<str>) -> RicerResult<RepoEntry> {
         debug!("Remove repository '{}' from configuration file", repo_name.as_ref());
         let repos = self.doc.get_mut("repos").ok_or(RicerError::NoReposSection)?;
@@ -144,15 +350,102 @@ impl ConfigFileManager for DefaultConfigFileManager {
     }
 
     /// Rename repository entry in configuration file data.
+    ///
+    /// # Preconditions
+    ///
+    /// 1. The `repos` section exists.
+    /// 2. The `repos` section is defined as a table.
+    /// 3. Repository definition exists in `repos` section.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Rename target repository with provided new name.
+    ///
+    /// # Invariants
+    ///
+    /// 1. Preserve original formatting and comments that existed beforehand.
+    ///
+    /// # Errors
+    ///
+    /// 1. Return [`RicerError::NoReposSection`] if `repos` section does not
+    ///    exist.
+    /// 2. Return [`RicerError::ReposSectionNotTable`] if `repos` section is
+    ///    not defined as a table.
+    /// 3. Return [`RicerError::NoRepoFound`] if target repository definition
+    ///    does not exist.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use anyhow::Result;
+    /// # fn main() -> Result<()> {
+    /// use ricer::config::file::{ConfigFileManager, DefaultConfigFileManager};
+    ///
+    /// let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    /// cfg_file_mgr.read("/path/to/config.toml")?;
+    /// cfg_file_mgr.rename_repo("vi", "vim")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`RicerError::NoReposSection`]: crate::error::RicerError::NoReposSection
+    /// [`RicerError::ReposSectionNotTable`]: crate::error::RicerError::ReposSectionNotTable
+    /// [`RicerError::NoRepoFound`]: crate::error::RicerError::NoRepoFound
     fn rename_repo(&mut self, from: impl AsRef<str>, to: impl AsRef<str>) -> RicerResult<()> {
         debug!("Rename repository '{}' to '{}' in configuration file", from.as_ref(), to.as_ref());
-        let mut repo = self.remove_repo(from.as_ref())?;
-        repo.name = to.as_ref().to_string();
-        self.add_repo(&repo)?;
+        let repos = self.doc.get_mut("repos").ok_or(RicerError::NoReposSection)?;
+        let repos = repos.as_table_mut().ok_or(RicerError::ReposSectionNotTable)?;
+        let (key, value) = repos
+            .remove_entry(from.as_ref())
+            .ok_or(RicerError::NoRepoFound { repo_name: from.as_ref().to_string() })?;
+
+        // Preserve decor (comments and formatting) from original key...
+        let key = Key::new(to.as_ref()).with_leaf_decor(key.leaf_decor().clone());
+        repos.insert_formatted(&key, value);
         Ok(())
     }
 
-    /// Deserialize command hook envry from parsed configuration file data.
+    /// Deserialize command hook entry from parsed configuration file data.
+    ///
+    /// # Preconditions
+    ///
+    /// 1. The `hooks` section exists.
+    /// 2. The `hooks` section is defined as a table.
+    /// 3. Command hook definition exists in `hooks` section.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Return deserialized [`CommandHookEntry`].
+    /// 2. Will not modify configuration file data.
+    ///
+    /// # Errors
+    ///
+    /// 1. Return [`RicerError::NoHooksSection`] if `hooks` section does not
+    ///    exist.
+    /// 2. Return [`RicerError::HooksSectionNotTable`] if `hooks` section is
+    ///    not defined as a table.
+    /// 3. Return [`RicerError::NoHookFound`] if target command hook definition
+    ///    does not exist.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use anyhow::Result;
+    /// # fn main() -> Result<()> {
+    /// use ricer::config::file::{ConfigFileManager, DefaultConfigFileManager};
+    ///
+    /// let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    /// cfg_file_mgr.read("/path/to/config.toml")?;
+    /// let hook = cfg_file_mgr.get_cmd_hook("commit")?;
+    /// println!("{:#?}", hook);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`CommandHookEntry`]: crate::config::file::hooks_section::CommandHookEntry
+    /// [`RicerError::NoHooksSection`]: crate::error::RicerError::NoHooksSection
+    /// [`RicerError::HooksSectionNotTable`]: crate::error::RicerError::HooksSectionNotTable
+    /// [`RicerError::NoHookFound`]: crate::error::RicerError::NoHookFound
     fn get_cmd_hook(&self, cmd_name: impl AsRef<str>) -> RicerResult<CommandHookEntry> {
         let hooks = self.doc.get("hooks").ok_or(RicerError::NoHooksSection)?;
         let hooks = hooks.as_table().ok_or(RicerError::HooksSectionNotTable)?;

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -33,7 +33,7 @@ pub trait ConfigFileManager {
     fn write(&mut self, path: impl AsRef<Path>) -> RicerResult<()>;
 
     /// Show current configuration file data in string form.
-    fn data(&self) -> String;
+    fn to_string(&self) -> String;
 
     /// Deserialize repository entry from parsed configuration file data.
     fn get_repo(&self, repo_name: impl AsRef<str>) -> RicerResult<RepoEntry>;
@@ -98,8 +98,8 @@ impl ConfigFileManager for DefaultConfigFileManager {
     }
 
     /// Show current configuration file data in string form.
-    fn data(&self) -> String {
-        todo!();
+    fn to_string(&self) -> String {
+        self.doc.to_string()
     }
 
     /// Deserialize repository entry from parsed configuration file data.

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -12,6 +12,8 @@
 //!
 //! [toml-spec]: https://toml.io/en/v1.0.0
 
+use log::debug;
+use std::fs::read_to_string;
 use std::path::Path;
 use toml_edit::DocumentMut;
 
@@ -19,8 +21,8 @@ pub mod hooks_section;
 pub mod repos_section;
 
 use crate::error::RicerResult;
-use repos_section::RepoEntry;
 use hooks_section::CommandHookEntry;
+use repos_section::RepoEntry;
 
 /// Configuration file manager representation.
 pub trait ConfigFileManager {
@@ -49,14 +51,43 @@ pub trait ConfigFileManager {
     fn get_cmd_hook(&self, cmd_name: impl AsRef<str>) -> RicerResult<CommandHookEntry>;
 }
 
+#[derive(Debug, Default)]
 pub struct DefaultConfigFileManager {
     doc: DocumentMut,
 }
 
+impl DefaultConfigFileManager {
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
 impl ConfigFileManager for DefaultConfigFileManager {
     /// Read from configuration file at provided path.
+    ///
+    /// # Preconditions
+    ///
+    /// 1. Configuration file exists at provided path.
+    /// 2. Configuration file contains valid TOML formatting.
+    ///
+    /// # Postconditions
+    ///
+    /// 1. Parse TOML data for future manipulation.
+    ///
+    /// # Invariants
+    ///
+    /// None.
+    ///
+    /// # Side Effects
+    ///
+    /// None.
     fn read(&mut self, path: impl AsRef<Path>) -> RicerResult<()> {
-        todo!();
+        debug!("Read configuration file from '{}'", path.as_ref().display());
+        let buffer = read_to_string(path.as_ref())?;
+        let doc: DocumentMut = buffer.parse()?;
+
+        self.doc = doc;
+        Ok(())
     }
 
     /// Write to configuration file at provided path.

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -104,7 +104,7 @@ impl ConfigFileManager for DefaultConfigFileManager {
 
     /// Deserialize repository entry from parsed configuration file data.
     fn get_repo(&self, repo_name: impl AsRef<str>) -> RicerResult<RepoEntry> {
-        debug!("Get repository definition '{}' from configuration file", repo_name.as_ref());
+        debug!("Get repository '{}' from configuration file", repo_name.as_ref());
         let repo_toml = self.doc.get("repos").ok_or(RicerError::NoReposSection)?;
         let repo_toml = repo_toml.as_table().ok_or(RicerError::ReposSectionNotTable)?;
         let repo_toml = repo_toml
@@ -115,7 +115,7 @@ impl ConfigFileManager for DefaultConfigFileManager {
 
     /// Serialize repository entry into parsed configuration file data.
     fn add_repo(&mut self, repo_entry: &RepoEntry) -> RicerResult<()> {
-        debug!("Add repository definition '{}' too configuration file", &repo_entry.name);
+        debug!("Add repository '{}' too configuration file", &repo_entry.name);
         let (repo_name, repo_data) = repo_entry.to_toml();
         if let Some(repos) = self.doc.get_mut("repos") {
             trace!("The 'repos' section exists, add to it");
@@ -135,7 +135,7 @@ impl ConfigFileManager for DefaultConfigFileManager {
 
     /// Remove repository entry from configuration file data.
     fn remove_repo(&mut self, repo_name: impl AsRef<str>) -> RicerResult<RepoEntry> {
-        debug!("Remove repository definition '{}' from configuration file", repo_name.as_ref());
+        debug!("Remove repository '{}' from configuration file", repo_name.as_ref());
         let repos = self.doc.get_mut("repos").ok_or(RicerError::NoReposSection)?;
         let repos = repos.as_table_mut().ok_or(RicerError::ReposSectionNotTable)?;
         let (repo_key, repo_data) = repos.remove_entry(repo_name.as_ref()).ok_or(
@@ -146,7 +146,11 @@ impl ConfigFileManager for DefaultConfigFileManager {
 
     /// Rename repository entry in configuration file data.
     fn rename_repo(&mut self, from: impl AsRef<str>, to: impl AsRef<str>) -> RicerResult<()> {
-        todo!();
+        debug!("Rename repository '{}' to '{}' in configuration file", from.as_ref(), to.as_ref());
+        let mut repo = self.remove_repo(from.as_ref())?;
+        repo.name = to.as_ref().to_string();
+        self.add_repo(&repo)?;
+        Ok(())
     }
 
     /// Deserialize command hook envry from parsed configuration file data.

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -12,15 +12,16 @@
 //!
 //! [toml-spec]: https://toml.io/en/v1.0.0
 
+use anyhow::anyhow;
 use log::debug;
 use std::fs::{read_to_string, write};
 use std::path::Path;
-use toml_edit::DocumentMut;
+use toml_edit::{DocumentMut, Item, Table};
 
 pub mod hooks_section;
 pub mod repos_section;
 
-use crate::error::RicerResult;
+use crate::error::{RicerError, RicerResult};
 use hooks_section::CommandHookEntry;
 use repos_section::RepoEntry;
 
@@ -109,7 +110,19 @@ impl ConfigFileManager for DefaultConfigFileManager {
 
     /// Serialize repository entry into parsed configuration file data.
     fn add_repo(&mut self, repo_entry: &RepoEntry) -> RicerResult<()> {
-        todo!();
+        let (repo_name, repo_data) = repo_entry.to_toml();
+        if let Some(repos_section) = self.doc.get_mut("repos") {
+            let repos_section = repos_section.as_table_mut().ok_or(RicerError::Unrecoverable(
+                anyhow!("The `repos` section is not defined as a table"),
+            ))?;
+            repos_section.insert(repo_name.get(), repo_data);
+        } else {
+            self.doc.insert("repos", Item::Table(Table::new()));
+            let repos = &mut self.doc["repos"];
+            repos.as_table_mut().unwrap().insert(repo_name.get(), repo_data);
+        }
+
+        Ok(())
     }
 
     /// Remove repository entry from configuration file data.

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -105,12 +105,12 @@ impl ConfigFileManager for DefaultConfigFileManager {
     /// Deserialize repository entry from parsed configuration file data.
     fn get_repo(&self, repo_name: impl AsRef<str>) -> RicerResult<RepoEntry> {
         debug!("Get repository '{}' from configuration file", repo_name.as_ref());
-        let repo_toml = self.doc.get("repos").ok_or(RicerError::NoReposSection)?;
-        let repo_toml = repo_toml.as_table().ok_or(RicerError::ReposSectionNotTable)?;
-        let repo_toml = repo_toml
+        let repos = self.doc.get("repos").ok_or(RicerError::NoReposSection)?;
+        let repos = repos.as_table().ok_or(RicerError::ReposSectionNotTable)?;
+        let repo = repos
             .get_key_value(repo_name.as_ref())
             .ok_or(RicerError::NoRepoFound { repo_name: repo_name.as_ref().to_string() })?;
-        Ok(RepoEntry::from(repo_toml))
+        Ok(RepoEntry::from(repo))
     }
 
     /// Serialize repository entry into parsed configuration file data.
@@ -119,8 +119,7 @@ impl ConfigFileManager for DefaultConfigFileManager {
         let (repo_name, repo_data) = repo_entry.to_toml();
         if let Some(repos) = self.doc.get_mut("repos") {
             trace!("The 'repos' section exists, add to it");
-            let repos =
-                repos.as_table_mut().ok_or(RicerError::ReposSectionNotTable)?;
+            let repos = repos.as_table_mut().ok_or(RicerError::ReposSectionNotTable)?;
             repos.insert(repo_name.get(), repo_data);
         } else {
             trace!("The 'repos' section does not exist, set it up and add to it");
@@ -138,9 +137,9 @@ impl ConfigFileManager for DefaultConfigFileManager {
         debug!("Remove repository '{}' from configuration file", repo_name.as_ref());
         let repos = self.doc.get_mut("repos").ok_or(RicerError::NoReposSection)?;
         let repos = repos.as_table_mut().ok_or(RicerError::ReposSectionNotTable)?;
-        let (repo_key, repo_data) = repos.remove_entry(repo_name.as_ref()).ok_or(
-            RicerError::NoRepoFound { repo_name: repo_name.as_ref().to_string() }
-        )?;
+        let (repo_key, repo_data) = repos
+            .remove_entry(repo_name.as_ref())
+            .ok_or(RicerError::NoRepoFound { repo_name: repo_name.as_ref().to_string() })?;
         Ok(RepoEntry::from((&repo_key, &repo_data)))
     }
 
@@ -155,6 +154,11 @@ impl ConfigFileManager for DefaultConfigFileManager {
 
     /// Deserialize command hook envry from parsed configuration file data.
     fn get_cmd_hook(&self, cmd_name: impl AsRef<str>) -> RicerResult<CommandHookEntry> {
-        todo!();
+        let hooks = self.doc.get("hooks").ok_or(RicerError::NoHooksSection)?;
+        let hooks = hooks.as_table().ok_or(RicerError::HooksSectionNotTable)?;
+        let hook = hooks
+            .get_key_value(cmd_name.as_ref())
+            .ok_or(RicerError::NoHookFound { cmd_name: cmd_name.as_ref().to_string() })?;
+        Ok(CommandHookEntry::from(hook))
     }
 }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -16,7 +16,7 @@ use anyhow::anyhow;
 use log::debug;
 use std::fs::{read_to_string, write};
 use std::path::Path;
-use toml_edit::{DocumentMut, Decor, Item, Table, Key};
+use toml_edit::{Decor, DocumentMut, Item, Key, Table};
 
 pub mod hooks_section;
 pub mod repos_section;
@@ -105,16 +105,20 @@ impl ConfigFileManager for DefaultConfigFileManager {
 
     /// Deserialize repository entry from parsed configuration file data.
     fn get_repo(&self, repo_name: impl AsRef<str>) -> RicerResult<RepoEntry> {
-        todo!();
+        let repo_toml = self.doc.get("repos").ok_or(RicerError::NoReposSection)?;
+        let repo_toml = repo_toml.as_table().ok_or(RicerError::ReposSectionNotTable)?;
+        let repo_toml = repo_toml
+            .get_key_value(repo_name.as_ref())
+            .ok_or(RicerError::NoRepoFound { repo_name: repo_name.as_ref().to_string() })?;
+        Ok(RepoEntry::from(repo_toml))
     }
 
     /// Serialize repository entry into parsed configuration file data.
     fn add_repo(&mut self, repo_entry: &RepoEntry) -> RicerResult<()> {
         let (repo_name, repo_data) = repo_entry.to_toml();
         if let Some(repos_section) = self.doc.get_mut("repos") {
-            let repos_section = repos_section.as_table_mut().ok_or(RicerError::Unrecoverable(
-                anyhow!("The `repos` section is not defined as a table"),
-            ))?;
+            let repos_section =
+                repos_section.as_table_mut().ok_or(RicerError::ReposSectionNotTable)?;
             repos_section.insert(repo_name.get(), repo_data);
         } else {
             let mut repo_section = Table::new();

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -13,7 +13,7 @@
 //! [toml-spec]: https://toml.io/en/v1.0.0
 
 use log::debug;
-use std::fs::read_to_string;
+use std::fs::{read_to_string, write};
 use std::path::Path;
 use toml_edit::DocumentMut;
 
@@ -85,14 +85,16 @@ impl ConfigFileManager for DefaultConfigFileManager {
         debug!("Read configuration file from '{}'", path.as_ref().display());
         let buffer = read_to_string(path.as_ref())?;
         let doc: DocumentMut = buffer.parse()?;
-
         self.doc = doc;
         Ok(())
     }
 
     /// Write to configuration file at provided path.
     fn write(&mut self, path: impl AsRef<Path>) -> RicerResult<()> {
-        todo!();
+        debug!("Write configuration file to '{}'", path.as_ref().display());
+        let buffer = self.doc.to_string();
+        write(path.as_ref(), buffer)?;
+        Ok(())
     }
 
     /// Show current configuration file data in string form.

--- a/src/config/file/hooks_section.rs
+++ b/src/config/file/hooks_section.rs
@@ -89,9 +89,9 @@ impl CommandHookEntry {
     ///
     /// let mut cmd_hook = CommandHookEntry::new("commit");
     /// let hook_entry = HookEntry::builder()
-    ///     .pre(Some("hook.sh"))
-    ///     .post(Some("hook.sh"))
-    ///     .repo(Some("vim"))
+    ///     .pre("hook.sh")
+    ///     .post("hook.sh")
+    ///     .repo("vim")
     ///     .build();
     /// cmd_hook.add_hook(hook_entry);
     /// ```
@@ -115,8 +115,11 @@ impl<'toml> Visit<'toml> for CommandHookEntry {
         let post = if let Some(post) = node.get("post") { post.as_str() } else { None };
         let repo = if let Some(repo) = node.get("repo") { repo.as_str() } else { None };
 
-        let hook_entry = HookEntry::builder().pre(pre).post(post).repo(repo).build();
-        self.add_hook(hook_entry);
+        let hook_entry = HookEntry::builder();
+        let hook_entry = if let Some(pre) = pre { hook_entry.pre(pre) } else { hook_entry };
+        let hook_entry = if let Some(post) = post { hook_entry.post(post) } else { hook_entry };
+        let hook_entry = if let Some(repo) = repo { hook_entry.repo(repo) } else { hook_entry };
+        self.add_hook(hook_entry.build());
 
         visit_inline_table(self, node);
     }
@@ -206,8 +209,8 @@ impl HookEntryBuilder {
     /// None.
     ///
     /// [`pre`]: #member.pre
-    pub fn pre(mut self, script_name: Option<impl AsRef<str>>) -> Self {
-        self.pre = script_name.map(|s| s.as_ref().to_string());
+    pub fn pre(mut self, script_name: impl Into<String>) -> Self {
+        self.pre = Some(script_name.into());
         self
     }
 
@@ -230,8 +233,8 @@ impl HookEntryBuilder {
     /// None.
     ///
     /// [`post`]: #member.post
-    pub fn post(mut self, script_name: Option<impl AsRef<str>>) -> Self {
-        self.post = script_name.map(|s| s.as_ref().to_string());
+    pub fn post(mut self, script_name: impl Into<String>) -> Self {
+        self.post = Some(script_name.into());
         self
     }
 
@@ -254,8 +257,8 @@ impl HookEntryBuilder {
     /// None.
     ///
     /// [`repo`]: #member.repo
-    pub fn repo(mut self, repo_name: Option<impl AsRef<str>>) -> Self {
-        self.repo = repo_name.map(|s| s.as_ref().to_string());
+    pub fn repo(mut self, repo_name: impl Into<String>) -> Self {
+        self.repo = Some(repo_name.into());
         self
     }
 
@@ -283,9 +286,9 @@ impl HookEntryBuilder {
     /// use ricer::config::file::hooks_section::HookEntryBuilder;
     ///
     /// let hook_entry = HookEntryBuilder::new()
-    ///     .pre(Some("hook.sh"))
-    ///     .post(Some("hook.sh"))
-    ///     .repo(Some("vim"))
+    ///     .pre("hook.sh")
+    ///     .post("hook.sh")
+    ///     .repo("vim")
     ///     .build();
     /// println!("{:#?}", hook_entry);
     /// ```

--- a/src/config/file/hooks_section.rs
+++ b/src/config/file/hooks_section.rs
@@ -37,21 +37,9 @@ pub struct CommandHookEntry {
 impl CommandHookEntry {
     /// Construct new command hook entry definition.
     ///
-    /// # Preconditions
-    ///
-    /// None.
-    ///
     /// # Postconditions
     ///
     /// 1. Return valid instance of command hook entry handler.
-    ///
-    /// # Invariants
-    ///
-    /// None.
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     ///
     /// # Examples
     ///
@@ -66,21 +54,9 @@ impl CommandHookEntry {
 
     /// Add hook entry into command hook definition.
     ///
-    /// # Preconditions
-    ///
-    /// None.
-    ///
     /// # Postconditions
     ///
     /// 1. Add hook entry to [`hooks`] field.
-    ///
-    /// # Invariants
-    ///
-    /// None.
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     ///
     /// # Examples
     ///
@@ -141,21 +117,9 @@ pub struct HookEntry {
 impl HookEntry {
     /// Build a new hook entry definition.
     ///
-    /// # Preconditions
-    ///
-    /// None.
-    ///
     /// # Postconditions
     ///
     /// 1. Return hook entry builder instance.
-    ///
-    /// # Invariants
-    ///
-    /// None.
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     pub fn builder() -> HookEntryBuilder {
         HookEntryBuilder::new()
     }
@@ -171,42 +135,18 @@ pub struct HookEntryBuilder {
 impl HookEntryBuilder {
     /// Construct new hook entry builder.
     ///
-    /// # Preconditions
-    ///
-    /// None.
-    ///
     /// # Postconditions
     ///
     /// 1. Return new instance of hook entry builder.
-    ///
-    /// # Invariants
-    ///
-    /// None.
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     pub fn new() -> Self {
         Default::default()
     }
 
     /// Set pre-script to run _before_ target command.
     ///
-    /// # Preconditions
-    ///
-    /// None.
-    ///
     /// # Postconditions
     ///
     /// 1. Set [`pre`] field.
-    ///
-    /// # Invariants
-    ///
-    /// None.
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     ///
     /// [`pre`]: #member.pre
     pub fn pre(mut self, script_name: impl Into<String>) -> Self {
@@ -216,21 +156,9 @@ impl HookEntryBuilder {
 
     /// Set post-script to run _before_ target command.
     ///
-    /// # postconditions
-    ///
-    /// None.
-    ///
     /// # Postconditions
     ///
     /// 1. Set [`post`] field.
-    ///
-    /// # Invariants
-    ///
-    /// None.
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     ///
     /// [`post`]: #member.post
     pub fn post(mut self, script_name: impl Into<String>) -> Self {
@@ -240,21 +168,9 @@ impl HookEntryBuilder {
 
     /// Set repo-script to run _before_ target command.
     ///
-    /// # repoconditions
-    ///
-    /// None.
-    ///
     /// # Postconditions
     ///
     /// 1. Set [`repo`] field.
-    ///
-    /// # Invariants
-    ///
-    /// None.
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     ///
     /// [`repo`]: #member.repo
     pub fn repo(mut self, repo_name: impl Into<String>) -> Self {
@@ -264,21 +180,9 @@ impl HookEntryBuilder {
 
     /// Build new [`HookEntry`].
     ///
-    /// # Preconditions
-    ///
-    /// None.
-    ///
     /// # Postconditions
     ///
     /// 1. Return new instance of [`HookEntry`].
-    ///
-    /// # Invariants
-    ///
-    /// None.
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     ///
     /// # Examples
     ///

--- a/src/config/file/hooks_section.rs
+++ b/src/config/file/hooks_section.rs
@@ -71,6 +71,8 @@ impl CommandHookEntry {
     ///     .build();
     /// cmd_hook.add_hook(hook_entry);
     /// ```
+    ///
+    /// [`hooks`]: #member.hooks
     pub fn add_hook(&mut self, hook: HookEntry) {
         self.hooks.push(hook);
     }

--- a/src/config/file/repos_section.rs
+++ b/src/config/file/repos_section.rs
@@ -69,21 +69,9 @@ pub struct RepoEntry {
 impl RepoEntry {
     /// Build new repository entry definition.
     ///
-    /// # Preconditions
-    ///
-    /// None.
-    ///
     /// # Postconditions
     ///
     /// 1. Return [`RepoEntryBuilder`].
-    ///
-    /// # Invariants
-    ///
-    /// None.
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     ///
     /// # Examples
     ///
@@ -98,21 +86,9 @@ impl RepoEntry {
 
     /// Serialize repository entry definition into a TOML item.
     ///
-    /// # Preconditions
-    ///
-    /// None.
-    ///
     /// # Postconditions
     ///
     /// 1. Return serialized repository entry into TOML document format.
-    ///
-    /// # Invariants
-    ///
-    /// None.
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     ///
     /// # Examples
     ///
@@ -210,10 +186,6 @@ pub struct RepoEntryBuilder {
 impl RepoEntryBuilder {
     /// Construct repository entry builder.
     ///
-    /// # Preconditions
-    ///
-    /// None.
-    ///
     /// # Postconditions
     ///
     /// 1. Return new instance of repository entry builder.
@@ -221,10 +193,6 @@ impl RepoEntryBuilder {
     /// # Invariants
     ///
     /// 1. No field is empty.
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     pub fn new(name: impl AsRef<str>) -> Self {
         Self {
             name: name.as_ref().to_string(),
@@ -237,19 +205,11 @@ impl RepoEntryBuilder {
 
     /// Set branch field.
     ///
-    /// # Preconditions
-    ///
-    /// None.
-    ///
     /// # Postconditions
     ///
     /// 1. Set [`branch`] field.
     ///
     /// Invariants
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     ///
     /// [`branch`]: #member.branch
     pub fn branch(mut self, branch: impl AsRef<str>) -> Self {
@@ -259,19 +219,11 @@ impl RepoEntryBuilder {
 
     /// Set remote field.
     ///
-    /// # Preconditions
-    ///
-    /// None.
-    ///
     /// # Postconditions
     ///
     /// 1. Set [`remote`] field.
     ///
     /// Invariants
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     ///
     /// [`remote`]: #member.remote
     pub fn remote(mut self, remote: impl AsRef<str>) -> Self {
@@ -281,19 +233,11 @@ impl RepoEntryBuilder {
 
     /// Set URL field.
     ///
-    /// # Preconditions
-    ///
-    /// None.
-    ///
     /// # Postconditions
     ///
     /// 1. Set [`url`] field.
     ///
     /// Invariants
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     ///
     /// [`url`]: #member.url
     pub fn url(mut self, url: impl AsRef<str>) -> Self {
@@ -303,19 +247,9 @@ impl RepoEntryBuilder {
 
     /// Set target field.
     ///
-    /// # Preconditions
-    ///
-    /// None.
-    ///
     /// # Postconditions
     ///
     /// 1. Set [`target`] field.
-    ///
-    /// Invariants
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     ///
     /// [`target`]: #member.target
     pub fn target(mut self, target: RepoTargetEntry) -> Self {
@@ -325,10 +259,6 @@ impl RepoEntryBuilder {
 
     /// Build new [`RepoEntry`].
     ///
-    /// # Preconditions
-    ///
-    /// None.
-    ///
     /// # Postconditions
     ///
     /// 1. Valid instance of [`RepoEntry`].
@@ -336,10 +266,6 @@ impl RepoEntryBuilder {
     /// # Invariants
     ///
     /// 1. No field is empty.
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     ///
     /// # Examples
     ///
@@ -444,42 +370,18 @@ pub struct RepoTargetEntryBuilder {
 impl RepoTargetEntryBuilder {
     /// Construct new repository target entry builder.
     ///
-    /// # Preconditions
-    ///
-    /// None.
-    ///
     /// # Postconditions
     ///
     /// 1. Return new repository target entry builder.
-    ///
-    /// # Invariants
-    ///
-    /// None.
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     pub fn new() -> Self {
         Default::default()
     }
 
     /// Set home target.
     ///
-    /// # Preconditions
-    ///
-    /// None.
-    ///
     /// # Postconditions
     ///
     /// 1. Set [`home`] field.
-    ///
-    /// # Invariants
-    ///
-    /// None.
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     ///
     /// [`home`]: #member.home
     pub fn home(mut self, home: bool) -> Self {
@@ -489,21 +391,9 @@ impl RepoTargetEntryBuilder {
 
     /// Set OS target.
     ///
-    /// # Preconditions
-    ///
-    /// None.
-    ///
     /// # Postconditions
     ///
     /// 1. Set [`os`] field.
-    ///
-    /// # Invariants
-    ///
-    /// None.
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     ///
     /// [`os`]: #member.os
     pub fn os(mut self, os: TargetOsOption) -> Self {
@@ -513,21 +403,9 @@ impl RepoTargetEntryBuilder {
 
     /// Set user target
     ///
-    /// # Preconditions
-    ///
-    /// None.
-    ///
     /// # Postconditions
     ///
     /// 1. Set [`user`] field.
-    ///
-    /// # Invariants
-    ///
-    /// None.
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     ///
     /// [`user`]: #member.user
     pub fn user(mut self, user: impl Into<String>) -> Self {
@@ -537,21 +415,9 @@ impl RepoTargetEntryBuilder {
 
     /// Set hostname target.
     ///
-    /// # Preconditions
-    ///
-    /// None.
-    ///
     /// # Postconditions
     ///
     /// 1. Set [`hostname`] field.
-    ///
-    /// # Invariants
-    ///
-    /// None.
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     ///
     /// [`hostname`]: #member.hostname
     pub fn hostname(mut self, hostname: impl Into<String>) -> Self {
@@ -561,21 +427,9 @@ impl RepoTargetEntryBuilder {
 
     /// Build new [`RepoTargetEntry`].
     ///
-    /// # Preconditions
-    ///
-    /// None.
-    ///
     /// # Postconditions
     ///
     /// 1. Return new [`RepoTargetEntry`].
-    ///
-    /// # Invariants
-    ///
-    /// None.
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     ///
     /// # Examples
     ///

--- a/src/config/file/repos_section.rs
+++ b/src/config/file/repos_section.rs
@@ -168,8 +168,8 @@ impl RepoEntry {
             if let Some(hostname) = &target.hostname {
                 target_data.insert("hostname", Value::from(hostname));
             }
+            repo_data.insert("target", Item::Value(Value::InlineTable(target_data)));
         }
-        repo_data.insert("target", Item::Value(Value::InlineTable(target_data)));
 
         let key = Key::new(&self.name);
         let value = Item::Table(repo_data);

--- a/src/config/file/repos_section.rs
+++ b/src/config/file/repos_section.rs
@@ -452,11 +452,11 @@ impl RepoTargetEntryBuilder {
     pub fn build(self) -> RepoTargetEntry {
         trace!("Build new target entry for repository entry definition");
         debug_assert!(
-            self.user.as_ref().is_some_and(|s| !s.is_empty()) || self.user == None,
+            self.user.as_ref().is_some_and(|s| !s.is_empty()) || self.user.is_none(),
             "User target is empty"
         );
         debug_assert!(
-            self.hostname.as_ref().is_some_and(|s| !s.is_empty()) || self.hostname == None,
+            self.hostname.as_ref().is_some_and(|s| !s.is_empty()) || self.hostname.is_none(),
             "Hostname target is empty"
         );
 

--- a/src/config/file/repos_section.rs
+++ b/src/config/file/repos_section.rs
@@ -29,6 +29,13 @@
 //! is using a specific operating system. Current values for `os` is _unix_,
 //! _macos_, _windows_, or _any_. The `user` and `hostname` fields will make
 //! Ricer only bootstrap a repository for a specific user and host.
+//!
+//! The `branch`, `remote`, and `url` fields are mandatory, while the `target`
+//! field is optional. All fields in the `target` field are optional as well.
+//! If there is no `target` field for a given repository definition, then Ricer
+//! will __always__ default to bootstrapping the repository regardless of OS,
+//! user, and host. Ricer will also make the repository not target the user's
+//! home directory as the primary working tree.
 
 use log::trace;
 use std::fmt::{Display, Formatter, Result};
@@ -56,7 +63,7 @@ pub struct RepoEntry {
     pub url: String,
 
     /// Bootstrapping options.
-    pub target: RepoTargetEntry,
+    pub target: Option<RepoTargetEntry>,
 }
 
 impl RepoEntry {
@@ -117,10 +124,10 @@ impl RepoEntry {
     /// use ricer::config::file::repos_section::{RepoEntry, RepoTargetEntry, TargetOsOption};
     ///
     /// let target_entry = RepoTargetEntry::builder()
-    ///    .home(true)
+    ///     .home(true)
     ///     .os(TargetOsOption::Windows)
-    ///     .user(Some("awkless"))
-    ///     .hostname(Some("lovelace"))
+    ///     .user("awkless")
+    ///     .hostname("lovelace")
     ///     .build();
     /// let repo_entry = RepoEntry::builder("test")
     ///     .branch("master")
@@ -145,17 +152,23 @@ impl RepoEntry {
         repo_data.insert("branch", Item::Value(Value::from(&self.branch)));
         repo_data.insert("remote", Item::Value(Value::from(&self.remote)));
         repo_data.insert("url", Item::Value(Value::from(&self.url)));
-        target_data.insert("home", Value::from(self.target.home));
-        target_data.insert("os", Value::from(self.target.os.to_string()));
+        if let Some(target) = &self.target {
+            if let Some(home) = target.home {
+                target_data.insert("home", Value::from(home));
+            }
 
-        if let Some(user) = &self.target.user {
-            target_data.insert("user", Value::from(user));
+            if let Some(os) = &target.os {
+                target_data.insert("os", Value::from(os.to_string()));
+            }
+
+            if let Some(user) = &target.user {
+                target_data.insert("user", Value::from(user));
+            }
+
+            if let Some(hostname) = &target.hostname {
+                target_data.insert("hostname", Value::from(hostname));
+            }
         }
-
-        if let Some(hostname) = &self.target.hostname {
-            target_data.insert("hostname", Value::from(hostname));
-        }
-
         repo_data.insert("target", Item::Value(Value::InlineTable(target_data)));
 
         let key = Key::new(&self.name);
@@ -191,7 +204,7 @@ pub struct RepoEntryBuilder {
     branch: String,
     remote: String,
     url: String,
-    target: RepoTargetEntry,
+    target: Option<RepoTargetEntry>,
 }
 
 impl RepoEntryBuilder {
@@ -306,7 +319,7 @@ impl RepoEntryBuilder {
     ///
     /// [`target`]: #member.target
     pub fn target(mut self, target: RepoTargetEntry) -> Self {
-        self.target = target;
+        self.target = Some(target);
         self
     }
 
@@ -386,11 +399,11 @@ impl<'toml> Visit<'toml> for RepoEntryBuilder {
 #[derive(Debug, Default, Eq, PartialEq)]
 pub struct RepoTargetEntry {
     /// Repository will use the user's home directory as the main working tree.
-    pub home: bool,
+    pub home: Option<bool>,
 
     /// Bootstrap repository if and only if user's is using a specific operating
     /// system.
-    pub os: TargetOsOption,
+    pub os: Option<TargetOsOption>,
 
     /// Bootstrap repository for a specific user only on the system.
     pub user: Option<String>,
@@ -408,8 +421,8 @@ impl RepoTargetEntry {
 impl<'toml> Visit<'toml> for RepoTargetEntryBuilder {
     fn visit_table_like_kv(&mut self, key: &'toml str, node: &'toml Item) {
         match key {
-            "home" => self.home = *node.as_bool().get_or_insert(false),
-            "os" => self.os = TargetOsOption::from(node.as_str().unwrap_or_default()),
+            "home" => self.home = node.as_bool(),
+            "os" => self.os = Some(TargetOsOption::from(node.as_str().unwrap_or_default())),
             "user" => self.user = node.as_str().map(|str| str.to_string()),
             "hostname" => self.hostname = node.as_str().map(|str| str.to_string()),
             &_ => visit_table_like_kv(self, key, node),
@@ -422,8 +435,8 @@ impl<'toml> Visit<'toml> for RepoTargetEntryBuilder {
 /// Builder for target bootstrap options for repository definition implementation.
 #[derive(Debug, Default, Eq, PartialEq)]
 pub struct RepoTargetEntryBuilder {
-    home: bool,
-    os: TargetOsOption,
+    home: Option<bool>,
+    os: Option<TargetOsOption>,
     user: Option<String>,
     hostname: Option<String>,
 }
@@ -470,7 +483,7 @@ impl RepoTargetEntryBuilder {
     ///
     /// [`home`]: #member.home
     pub fn home(mut self, home: bool) -> Self {
-        self.home = home;
+        self.home = Some(home);
         self
     }
 
@@ -494,7 +507,7 @@ impl RepoTargetEntryBuilder {
     ///
     /// [`os`]: #member.os
     pub fn os(mut self, os: TargetOsOption) -> Self {
-        self.os = os;
+        self.os = Some(os);
         self
     }
 
@@ -517,8 +530,8 @@ impl RepoTargetEntryBuilder {
     /// None.
     ///
     /// [`user`]: #member.user
-    pub fn user(mut self, user: Option<impl AsRef<str>>) -> Self {
-        self.user = user.map(|s| s.as_ref().to_string());
+    pub fn user(mut self, user: impl Into<String>) -> Self {
+        self.user = Some(user.into());
         self
     }
 
@@ -541,8 +554,8 @@ impl RepoTargetEntryBuilder {
     /// None.
     ///
     /// [`hostname`]: #member.hostname
-    pub fn hostname(mut self, hostname: Option<impl AsRef<str>>) -> Self {
-        self.hostname = hostname.map(|s| s.as_ref().to_string());
+    pub fn hostname(mut self, hostname: impl Into<String>) -> Self {
+        self.hostname = Some(hostname.into());
         self
     }
 
@@ -574,8 +587,8 @@ impl RepoTargetEntryBuilder {
     /// let builder = RepoTargetEntryBuilder::new()
     ///     .home(true)
     ///     .os(TargetOsOption::Unix)
-    ///     .user(Some("awkless"))
-    ///     .hostname(Some("lovelace"))
+    ///     .user("awkless")
+    ///     .hostname("lovelace")
     ///     .build();
     /// # Ok(())
     /// # }
@@ -584,6 +597,14 @@ impl RepoTargetEntryBuilder {
     /// [`os`]: #member.os
     pub fn build(self) -> RepoTargetEntry {
         trace!("Build new target entry for repository entry definition");
+        debug_assert!(
+            self.user.as_ref().is_some_and(|s| !s.is_empty()) || self.user == None,
+            "User target is empty"
+        );
+        debug_assert!(
+            self.hostname.as_ref().is_some_and(|s| !s.is_empty()) || self.hostname == None,
+            "Hostname target is empty"
+        );
 
         RepoTargetEntry { home: self.home, os: self.os, user: self.user, hostname: self.hostname }
     }

--- a/src/config/locator.rs
+++ b/src/config/locator.rs
@@ -46,21 +46,9 @@ impl DefaultXdgBaseDirSpec {
     /// Construct new instance of default XDG Base Directory Specification
     /// handler.
     ///
-    /// # Preconditions
-    ///
-    /// None.
-    ///
     /// # Postconditions
     ///
     /// 1. Return Default XDG Base Directory Specification handler instance.
-    ///
-    /// # Invariants
-    ///
-    /// None.
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     ///
     /// # Errors
     ///
@@ -96,10 +84,6 @@ impl DefaultXdgBaseDirSpec {
 impl XdgBaseDirSpec for DefaultXdgBaseDirSpec {
     /// Get path of `$XDG_CONFIG_HOME`.
     ///
-    /// # Preconditions
-    ///
-    /// None.
-    ///
     /// # Postconditions
     ///
     /// 1. Return path of `$XDG_CONFIG_HOME`.
@@ -108,9 +92,6 @@ impl XdgBaseDirSpec for DefaultXdgBaseDirSpec {
     ///
     /// 1. Returned path is guaranteed to be absolute.
     ///
-    /// # Side Effects
-    ///
-    /// None.
     fn config_home_dir(&self) -> &Path {
         let path = self.xdg_spec.config_dir();
         debug_assert!(path.is_absolute(), "Path of $XDG_CONFIG_HOME is not absolute");
@@ -150,10 +131,6 @@ impl DefaultConfigDirLocator {
     /// # Invariants
     ///
     /// 1. Located path to configuration directory is absolute.
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     ///
     /// # Errors
     ///
@@ -201,10 +178,6 @@ impl DefaultConfigDirLocator {
 impl ConfigDirLocator for DefaultConfigDirLocator {
     /// Get located path to configuration directory.
     ///
-    /// # Preconditions
-    ///
-    /// None.
-    ///
     /// # Postconditions
     ///
     /// 1. Return path of `$XDG_CONFIG_HOME/ricer`.
@@ -212,10 +185,6 @@ impl ConfigDirLocator for DefaultConfigDirLocator {
     /// # Invariants
     ///
     /// 1. Returned path is guaranteed to be absolute.
-    ///
-    /// # Side Effects
-    ///
-    /// None.
     fn config_dir(&self) -> &Path {
         self.config_dir.as_path()
     }
@@ -233,14 +202,6 @@ impl ConfigDirLocator for DefaultConfigDirLocator {
 /// # Postconditions
 ///
 /// 1. Return instance of [`DefaultConfigDirLocator`].
-///
-/// # Invariants
-///
-/// None.
-///
-/// # Side Effects
-///
-/// None.
 ///
 /// # Errors
 ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,3 +35,9 @@ impl From<std::io::Error> for RicerError {
         RicerError::Unrecoverable(anyhow!("{}", err))
     }
 }
+
+impl From<toml_edit::TomlError> for RicerError {
+    fn from(err: toml_edit::TomlError) -> RicerError {
+        RicerError::Unrecoverable(anyhow!("{}", err))
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,11 @@ use anyhow::anyhow;
 pub type RicerResult<T> = Result<T, RicerError>;
 
 /// All possible error types in Ricer's internal API.
+///
+/// Do note that the documented description of each error type only provides
+/// the _expectation_ on recoverability. Please refer to the module API that
+/// uses these error types for what is really going to happen if Ricer
+/// encounters these errors.
 #[derive(Debug, thiserror::Error)]
 pub enum RicerError {
     /// Configuration directory located, but does not exist.
@@ -22,10 +27,62 @@ pub enum RicerError {
     #[error("Configuration directory located at expected path, but does not exist")]
     NoConfigDir(#[source] anyhow::Error),
 
-    /// Issued error is not recoverable.
+    /// Configuration file does not have a `repos` section.
     ///
-    /// Caller is either expected to pass this error up the call chain, or
-    /// panic as there is no expected way to recover from this error.
+    /// Recoverability depends on context. If user is adding a new repository to
+    /// the configuration file, then just create the `repos` section. However,
+    /// if the user is trying to obtain repository data from the configuration
+    /// file with the `repos` section not existing, then this error is deemed
+    /// unrecoverable as the user _needs to add_ a repository definition, or
+    /// create the `repos` section themselves.
+    #[error("Configuration file does not have a 'repos' section")]
+    NoReposSection,
+
+    /// Configuration file does not define `repos` section as a table.
+    ///
+    /// The user can define `repos` as a key/value pair, which is not what Ricer
+    /// expects. This one is currently considered unrecoverable, requiring the
+    /// user to remove their key/value pair definition of `repos`.
+    #[error("Configuration file does not define 'repos' section as a table")]
+    ReposSectionNotTable,
+
+    /// Configuration file does not contain repository definition in `repos` section.
+    ///
+    /// This is currently considered unrecoverable. The user is expected to
+    /// _add_ a repository definition in order to later retieve it.
+    #[error("Configuration file does not have repository '{repo_name}' in 'repos' section")]
+    NoRepoFound { repo_name: String },
+
+    /// Configuration file does not have a `hooks` section.
+    ///
+    /// Recoverability depends on context. If the user is adding a command hook
+    /// definition, then just create the `hooks` section. If the user is trying
+    /// to retrieve a command hook definition without a `hooks` section, then
+    /// this error is unrecoverable, because the user first needs to _add_ a
+    /// command _hook_ or `hooks` section to avoid this error.
+    #[error("Configuration file does not have a 'hooks' section")]
+    NoHooksSection,
+
+    /// Configuration file does not define `hooks` section as a table.
+    ///
+    /// The user can define `hooks` as a key/value pair, which is not what Ricer
+    /// expects. This one is currently considered unrecoverable, requiring the
+    /// user to remove their key/value pair definition of `hooks`.
+    #[error("Configuration file does not define 'hooks' section as a table")]
+    HooksSectionNotTable,
+
+    /// Configuration file does not contain command hook definition in `hooks`
+    /// section.
+    ///
+    /// This is currently considered unrecoverable. The user is expected to
+    /// _add_ a command hook definition in order to later retieve it.
+    #[error("Configuration file does not have command hook '{cmd_name}' in 'hooks' section")]
+    NoHookFound { cmd_name: String },
+
+    /// External error is not recoverable.
+    ///
+    /// Mainly used to convert external error types into a valid [`RicerError`]
+    /// variant.
     #[error(transparent)]
     Unrecoverable(#[from] anyhow::Error),
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5,6 +5,8 @@ mod locator;
 
 mod dir;
 
+mod file;
+
 mod cli;
 
 mod repos_section;

--- a/src/tests/file.rs
+++ b/src/tests/file.rs
@@ -18,7 +18,7 @@ fn config_file_fixture() -> FakeConfigDir {
             # The following should not be overwritten.
             [repos.vim]
             branch = "main"
-            remote = "orign"
+            remote = "origin"
             url = "https://github.com/awkless/vim.git"
             target = { home = true, os = "unix", user = "awkless", hostname = "lovelace" }
 
@@ -35,6 +35,11 @@ fn config_file_fixture() -> FakeConfigDir {
 #[fixture]
 fn empty_config_file_fixture() -> FakeConfigDir {
     FakeConfigDir::builder().config_file("# This comment should not be overwritten\n").build()
+}
+
+#[fixture]
+fn repos_section_not_table_fixture() -> FakeConfigDir {
+    FakeConfigDir::builder().config_file(r#"repos = "not a table!""#).build()
 }
 
 #[rstest]
@@ -70,4 +75,78 @@ fn write_serializes_config_file_correctly(mut config_file_fixture: FakeConfigDir
     let expect = cfg_file_stub.data();
     let result = cfg_file_mgr.to_string();
     assert_eq!(expect, result);
+}
+
+#[rstest]
+fn add_repo_serializes_correctly_to_existing_repos_table(config_file_fixture: FakeConfigDir) {
+    let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    cfg_file_mgr
+        .read(config_file_fixture.config_file_stub().as_path())
+        .expect("Expect success");
+    let new_repo = RepoEntry::builder("dwm")
+        .branch("master")
+        .remote("upstream")
+        .url("https://github.com/awkless/dwm.git")
+        .build();
+    cfg_file_mgr.add_repo(&new_repo).expect("Expect success");
+    let expect = indoc! {r#"
+            # The following should not be overwritten.
+            [repos.vim]
+            branch = "main"
+            remote = "origin"
+            url = "https://github.com/awkless/vim.git"
+            target = { home = true, os = "unix", user = "awkless", hostname = "lovelace" }
+
+            [repos.dwm]
+            branch = "master"
+            remote = "upstream"
+            url = "https://github.com/awkless/dwm.git"
+
+            # The following should not be overwritten.
+            [hooks]
+            commit = [
+                { pre = "hook.sh", post = "hook.sh", repo = "vim" },
+                { pre = "hook.sh" }
+            ]
+        "#};
+    let result = cfg_file_mgr.to_string();
+    assert_eq!(expect, result);
+}
+
+#[rstest]
+fn add_repo_serializes_corretly_with_no_repos_table(empty_config_file_fixture: FakeConfigDir) {
+    let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    cfg_file_mgr
+        .read(empty_config_file_fixture.config_file_stub().as_path())
+        .expect("Expect success");
+    let new_repo = RepoEntry::builder("dwm")
+        .branch("master")
+        .remote("upstream")
+        .url("https://github.com/awkless/dwm.git")
+        .build();
+    cfg_file_mgr.add_repo(&new_repo).expect("Expect success");
+    let expect = indoc! {r#"
+        [repos.dwm]
+        branch = "master"
+        remote = "upstream"
+        url = "https://github.com/awkless/dwm.git"
+        # This comment should not be overwritten
+        "#};
+    let result = cfg_file_mgr.to_string();
+    assert_eq!(expect, result);
+}
+
+#[rstest]
+fn add_repo_catches_non_table_repos_section(repos_section_not_table_fixture: FakeConfigDir) {
+    let mut cfg_file_mgr = DefaultConfigFileManager::new(); 
+    cfg_file_mgr
+        .read(repos_section_not_table_fixture.config_file_stub().as_path())
+        .expect("Expect success");
+    let new_repo = RepoEntry::builder("dwm")
+        .branch("master")
+        .remote("upstream")
+        .url("https://github.com/awkless/dwm.git")
+        .build();
+    let result = cfg_file_mgr.add_repo(&new_repo);
+    assert!(matches!(result, Err(RicerError::Unrecoverable(..))));
 }

--- a/src/tests/file.rs
+++ b/src/tests/file.rs
@@ -285,7 +285,9 @@ fn get_cmd_hook_deserializes_correctly(config_file_fixture: FakeConfigDir) {
 #[rstest]
 fn get_cmd_hook_catches_catches_no_hooks_section(empty_config_file_fixture: FakeConfigDir) {
     let mut cfg_file_mgr = DefaultConfigFileManager::new();
-    cfg_file_mgr.read(empty_config_file_fixture.config_file_stub().as_path()).expect("Expect success");
+    cfg_file_mgr
+        .read(empty_config_file_fixture.config_file_stub().as_path())
+        .expect("Expect success");
     let result = cfg_file_mgr.get_cmd_hook("nonexistant");
     assert!(matches!(result, Err(RicerError::NoHooksSection)));
 }
@@ -293,7 +295,9 @@ fn get_cmd_hook_catches_catches_no_hooks_section(empty_config_file_fixture: Fake
 #[rstest]
 fn get_cmd_hook_catches_non_table_hooks_section(non_table_sections_fixture: FakeConfigDir) {
     let mut cfg_file_mgr = DefaultConfigFileManager::new();
-    cfg_file_mgr.read(non_table_sections_fixture.config_file_stub().as_path()).expect("Expect success");
+    cfg_file_mgr
+        .read(non_table_sections_fixture.config_file_stub().as_path())
+        .expect("Expect success");
     let result = cfg_file_mgr.get_cmd_hook("nonexistant");
     assert!(matches!(result, Err(RicerError::HooksSectionNotTable)));
 }

--- a/src/tests/file.rs
+++ b/src/tests/file.rs
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
+
+use indoc::indoc;
+use pretty_assertions::assert_eq;
+use rstest::{fixture, rstest};
+
+use crate::config::file::{ConfigFileManager, DefaultConfigFileManager};
+use crate::error::RicerError;
+
+use ricer_test_tools::fakes::FakeConfigDir;
+
+#[fixture]
+fn config_file_fixture() -> FakeConfigDir {
+    FakeConfigDir::builder()
+        .config_file(indoc! {r#"
+            # The following should not be overwritten.
+            [repos.vim]
+            branch = "main"
+            remote = "orign"
+            url = "https://github.com/awkless/vim.git"
+            target = { home = true, os = "unix", user = "awkless", hostname = "lovelace" }
+
+            # The following should not be overwritten.
+            [hooks]
+            commit = [
+                { pre = "hook.sh", post = "hook.sh", repo = "vim" },
+                { pre = "hook.sh" }
+            ]
+            "#})
+        .build()
+}
+
+#[fixture]
+fn empty_config_file_fixture() -> FakeConfigDir {
+    FakeConfigDir::builder().config_file("# This comment should not be overwritten\n").build()
+}
+
+#[rstest]
+fn read_parses_config_file_correctly(config_file_fixture: FakeConfigDir) {
+    let cfg_stub = config_file_fixture.config_file_stub();
+    let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    cfg_file_mgr.read(cfg_stub.as_path()).expect("Expect succes");
+
+    let expect = cfg_stub.data();
+    let result = cfg_file_mgr.to_string();
+    assert_eq!(expect, result);
+}
+
+#[test]
+fn read_catches_inexistent_config_file() {
+    let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    let result = cfg_file_mgr.read("nonexistant");
+    assert!(matches!(result, Err(RicerError::Unrecoverable(..))));
+}

--- a/src/tests/file.rs
+++ b/src/tests/file.rs
@@ -5,6 +5,7 @@ use indoc::indoc;
 use pretty_assertions::assert_eq;
 use rstest::{fixture, rstest};
 
+use crate::config::file::hooks_section::{CommandHookEntry, HookEntry};
 use crate::config::file::repos_section::{RepoEntry, RepoTargetEntry, TargetOsOption};
 use crate::config::file::{ConfigFileManager, DefaultConfigFileManager};
 use crate::error::RicerError;
@@ -38,8 +39,13 @@ fn empty_config_file_fixture() -> FakeConfigDir {
 }
 
 #[fixture]
-fn repos_section_not_table_fixture() -> FakeConfigDir {
-    FakeConfigDir::builder().config_file(r#"repos = "not a table!""#).build()
+fn non_table_sections_fixture() -> FakeConfigDir {
+    FakeConfigDir::builder()
+        .config_file(indoc! {r#"
+            repos = "not a table!"
+            hooks = "not a table!"
+        "#})
+        .build()
 }
 
 #[rstest]
@@ -150,10 +156,10 @@ fn get_repo_catches_no_repos_section(empty_config_file_fixture: FakeConfigDir) {
 }
 
 #[rstest]
-fn get_repo_catches_non_table_repos_section(repos_section_not_table_fixture: FakeConfigDir) {
+fn get_repo_catches_non_table_repos_section(non_table_sections_fixture: FakeConfigDir) {
     let mut cfg_file_mgr = DefaultConfigFileManager::new();
     cfg_file_mgr
-        .read(repos_section_not_table_fixture.config_file_stub().as_path())
+        .read(non_table_sections_fixture.config_file_stub().as_path())
         .expect("Expect success");
     let result = cfg_file_mgr.get_repo("nonexistant");
     assert!(matches!(result, Err(RicerError::ReposSectionNotTable)));
@@ -183,10 +189,10 @@ fn add_repo_serializes_corretly_with_no_repos_table(empty_config_file_fixture: F
 }
 
 #[rstest]
-fn add_repo_catches_non_table_repos_section(repos_section_not_table_fixture: FakeConfigDir) {
+fn add_repo_catches_non_table_repos_section(non_table_sections_fixture: FakeConfigDir) {
     let mut cfg_file_mgr = DefaultConfigFileManager::new();
     cfg_file_mgr
-        .read(repos_section_not_table_fixture.config_file_stub().as_path())
+        .read(non_table_sections_fixture.config_file_stub().as_path())
         .expect("Expect success");
     let new_repo = RepoEntry::builder("dwm")
         .branch("master")
@@ -200,9 +206,7 @@ fn add_repo_catches_non_table_repos_section(repos_section_not_table_fixture: Fak
 #[rstest]
 fn remove_repo_removes_repo_from_toml_data(config_file_fixture: FakeConfigDir) {
     let mut cfg_file_mgr = DefaultConfigFileManager::new();
-    cfg_file_mgr
-        .read(config_file_fixture.config_file_stub().as_path())
-        .expect("Expect success");
+    cfg_file_mgr.read(config_file_fixture.config_file_stub().as_path()).expect("Expect success");
     let expect = indoc! {r#"
 
         # The following should not be overwritten.
@@ -220,9 +224,7 @@ fn remove_repo_removes_repo_from_toml_data(config_file_fixture: FakeConfigDir) {
 #[rstest]
 fn remove_repo_provides_correct_repo_data(config_file_fixture: FakeConfigDir) {
     let mut cfg_file_mgr = DefaultConfigFileManager::new();
-    cfg_file_mgr
-        .read(config_file_fixture.config_file_stub().as_path())
-        .expect("Expect success");
+    cfg_file_mgr.read(config_file_fixture.config_file_stub().as_path()).expect("Expect success");
     let target = RepoTargetEntry::builder()
         .home(true)
         .os(TargetOsOption::Unix)
@@ -250,10 +252,10 @@ fn remove_repo_catches_no_repos_section(empty_config_file_fixture: FakeConfigDir
 }
 
 #[rstest]
-fn remove_repo_catches_non_table_repos_section(repos_section_not_table_fixture: FakeConfigDir) {
+fn remove_repo_catches_non_table_repos_section(non_table_sections_fixture: FakeConfigDir) {
     let mut cfg_file_mgr = DefaultConfigFileManager::new();
     cfg_file_mgr
-        .read(repos_section_not_table_fixture.config_file_stub().as_path())
+        .read(non_table_sections_fixture.config_file_stub().as_path())
         .expect("Expect success");
     let result = cfg_file_mgr.remove_repo("nonexistant");
     assert!(matches!(result, Err(RicerError::ReposSectionNotTable)));
@@ -262,9 +264,44 @@ fn remove_repo_catches_non_table_repos_section(repos_section_not_table_fixture: 
 #[rstest]
 fn remove_repo_catches_inexistent_repo(config_file_fixture: FakeConfigDir) {
     let mut cfg_file_mgr = DefaultConfigFileManager::new();
-    cfg_file_mgr
-        .read(config_file_fixture.config_file_stub().as_path())
-        .expect("Expect success");
+    cfg_file_mgr.read(config_file_fixture.config_file_stub().as_path()).expect("Expect success");
     let result = cfg_file_mgr.remove_repo("nonexistant");
     assert!(matches!(result, Err(RicerError::NoRepoFound { .. })));
+}
+
+#[rstest]
+fn get_cmd_hook_deserializes_correctly(config_file_fixture: FakeConfigDir) {
+    let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    cfg_file_mgr.read(config_file_fixture.config_file_stub().as_path()).expect("Expect success");
+    let mut expect = CommandHookEntry::new("commit");
+    let full_hook_entry = HookEntry::builder().pre("hook.sh").post("hook.sh").repo("vim").build();
+    let small_hook_entry = HookEntry::builder().pre("hook.sh").build();
+    expect.add_hook(full_hook_entry);
+    expect.add_hook(small_hook_entry);
+    let result = cfg_file_mgr.get_cmd_hook("commit").expect("Expect success");
+    assert_eq!(expect, result);
+}
+
+#[rstest]
+fn get_cmd_hook_catches_catches_no_hooks_section(empty_config_file_fixture: FakeConfigDir) {
+    let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    cfg_file_mgr.read(empty_config_file_fixture.config_file_stub().as_path()).expect("Expect success");
+    let result = cfg_file_mgr.get_cmd_hook("nonexistant");
+    assert!(matches!(result, Err(RicerError::NoHooksSection)));
+}
+
+#[rstest]
+fn get_cmd_hook_catches_non_table_hooks_section(non_table_sections_fixture: FakeConfigDir) {
+    let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    cfg_file_mgr.read(non_table_sections_fixture.config_file_stub().as_path()).expect("Expect success");
+    let result = cfg_file_mgr.get_cmd_hook("nonexistant");
+    assert!(matches!(result, Err(RicerError::HooksSectionNotTable)));
+}
+
+#[rstest]
+fn get_cmd_hook_catches_inexistent_cmd_hook(config_file_fixture: FakeConfigDir) {
+    let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    cfg_file_mgr.read(config_file_fixture.config_file_stub().as_path()).expect("Expect success");
+    let result = cfg_file_mgr.get_cmd_hook("nonexistant");
+    assert!(matches!(result, Err(RicerError::NoHookFound { .. })));
 }

--- a/src/tests/file.rs
+++ b/src/tests/file.rs
@@ -5,7 +5,7 @@ use indoc::indoc;
 use pretty_assertions::assert_eq;
 use rstest::{fixture, rstest};
 
-use crate::config::file::repos_section::RepoEntry;
+use crate::config::file::repos_section::{RepoEntry, RepoTargetEntry, TargetOsOption};
 use crate::config::file::{ConfigFileManager, DefaultConfigFileManager};
 use crate::error::RicerError;
 
@@ -80,9 +80,7 @@ fn write_serializes_config_file_correctly(mut config_file_fixture: FakeConfigDir
 #[rstest]
 fn add_repo_serializes_correctly_to_existing_repos_table(config_file_fixture: FakeConfigDir) {
     let mut cfg_file_mgr = DefaultConfigFileManager::new();
-    cfg_file_mgr
-        .read(config_file_fixture.config_file_stub().as_path())
-        .expect("Expect success");
+    cfg_file_mgr.read(config_file_fixture.config_file_stub().as_path()).expect("Expect success");
     let new_repo = RepoEntry::builder("dwm")
         .branch("master")
         .remote("upstream")
@@ -114,6 +112,54 @@ fn add_repo_serializes_correctly_to_existing_repos_table(config_file_fixture: Fa
 }
 
 #[rstest]
+fn get_repo_deserializes_correctly(config_file_fixture: FakeConfigDir) {
+    let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    cfg_file_mgr.read(config_file_fixture.config_file_stub().as_path()).expect("Expect success");
+    let target = RepoTargetEntry::builder()
+        .home(true)
+        .os(TargetOsOption::Unix)
+        .user("awkless")
+        .hostname("lovelace")
+        .build();
+    let expect = RepoEntry::builder("vim")
+        .branch("main")
+        .remote("origin")
+        .url("https://github.com/awkless/vim.git")
+        .target(target)
+        .build();
+    let result = cfg_file_mgr.get_repo("vim").expect("Expect success");
+    assert_eq!(expect, result);
+}
+
+#[rstest]
+fn get_repo_catches_inexistent_repo(config_file_fixture: FakeConfigDir) {
+    let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    cfg_file_mgr.read(config_file_fixture.config_file_stub().as_path()).expect("Expect success");
+    let result = cfg_file_mgr.get_repo("nonexistant");
+    assert!(matches!(result, Err(RicerError::NoRepoFound { .. })));
+}
+
+#[rstest]
+fn get_repo_catches_no_repos_section(empty_config_file_fixture: FakeConfigDir) {
+    let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    cfg_file_mgr
+        .read(empty_config_file_fixture.config_file_stub().as_path())
+        .expect("Expect success");
+    let result = cfg_file_mgr.get_repo("nonexistant");
+    assert!(matches!(result, Err(RicerError::NoReposSection)));
+}
+
+#[rstest]
+fn get_repo_catches_non_table_repos_section(repos_section_not_table_fixture: FakeConfigDir) {
+    let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    cfg_file_mgr
+        .read(repos_section_not_table_fixture.config_file_stub().as_path())
+        .expect("Expect success");
+    let result = cfg_file_mgr.get_repo("nonexistant");
+    assert!(matches!(result, Err(RicerError::ReposSectionNotTable)));
+}
+
+#[rstest]
 fn add_repo_serializes_corretly_with_no_repos_table(empty_config_file_fixture: FakeConfigDir) {
     let mut cfg_file_mgr = DefaultConfigFileManager::new();
     cfg_file_mgr
@@ -138,7 +184,7 @@ fn add_repo_serializes_corretly_with_no_repos_table(empty_config_file_fixture: F
 
 #[rstest]
 fn add_repo_catches_non_table_repos_section(repos_section_not_table_fixture: FakeConfigDir) {
-    let mut cfg_file_mgr = DefaultConfigFileManager::new(); 
+    let mut cfg_file_mgr = DefaultConfigFileManager::new();
     cfg_file_mgr
         .read(repos_section_not_table_fixture.config_file_stub().as_path())
         .expect("Expect success");
@@ -148,5 +194,5 @@ fn add_repo_catches_non_table_repos_section(repos_section_not_table_fixture: Fak
         .url("https://github.com/awkless/dwm.git")
         .build();
     let result = cfg_file_mgr.add_repo(&new_repo);
-    assert!(matches!(result, Err(RicerError::Unrecoverable(..))));
+    assert!(matches!(result, Err(RicerError::ReposSectionNotTable)));
 }

--- a/src/tests/file.rs
+++ b/src/tests/file.rs
@@ -5,6 +5,7 @@ use indoc::indoc;
 use pretty_assertions::assert_eq;
 use rstest::{fixture, rstest};
 
+use crate::config::file::repos_section::RepoEntry;
 use crate::config::file::{ConfigFileManager, DefaultConfigFileManager};
 use crate::error::RicerError;
 
@@ -37,12 +38,12 @@ fn empty_config_file_fixture() -> FakeConfigDir {
 }
 
 #[rstest]
-fn read_parses_config_file_correctly(config_file_fixture: FakeConfigDir) {
-    let cfg_stub = config_file_fixture.config_file_stub();
+fn read_deserializes_config_file_correctly(config_file_fixture: FakeConfigDir) {
+    let cfg_file_stub = config_file_fixture.config_file_stub();
     let mut cfg_file_mgr = DefaultConfigFileManager::new();
-    cfg_file_mgr.read(cfg_stub.as_path()).expect("Expect succes");
+    cfg_file_mgr.read(cfg_file_stub.as_path()).expect("Expect succes");
 
-    let expect = cfg_stub.data();
+    let expect = cfg_file_stub.data();
     let result = cfg_file_mgr.to_string();
     assert_eq!(expect, result);
 }
@@ -52,4 +53,21 @@ fn read_catches_inexistent_config_file() {
     let mut cfg_file_mgr = DefaultConfigFileManager::new();
     let result = cfg_file_mgr.read("nonexistant");
     assert!(matches!(result, Err(RicerError::Unrecoverable(..))));
+}
+
+#[rstest]
+fn write_serializes_config_file_correctly(mut config_file_fixture: FakeConfigDir) {
+    let cfg_file_stub = config_file_fixture.config_file_stub_mut();
+    let new_repo = RepoEntry::builder("dwm")
+        .branch("master")
+        .remote("upstream")
+        .url("https://github.com/awkless/dwm.git")
+        .build();
+    let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    cfg_file_mgr.add_repo(&new_repo).expect("Expect success");
+    cfg_file_mgr.write(cfg_file_stub.as_path()).expect("Expect success");
+    cfg_file_stub.sync();
+    let expect = cfg_file_stub.data();
+    let result = cfg_file_mgr.to_string();
+    assert_eq!(expect, result);
 }

--- a/src/tests/file.rs
+++ b/src/tests/file.rs
@@ -270,6 +270,58 @@ fn remove_repo_catches_inexistent_repo(config_file_fixture: FakeConfigDir) {
 }
 
 #[rstest]
+fn rename_repo_works_correctly(config_file_fixture: FakeConfigDir) {
+    let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    cfg_file_mgr.read(config_file_fixture.config_file_stub().as_path()).expect("Expect success");
+    cfg_file_mgr.rename_repo("vim", "vimrc").expect("Expect success");
+    let expect = indoc! {r#"
+        # The following should not be overwritten.
+        [repos.vimrc]
+        branch = "main"
+        remote = "origin"
+        url = "https://github.com/awkless/vim.git"
+        target = { home = true, os = "unix", user = "awkless", hostname = "lovelace" }
+
+        # The following should not be overwritten.
+        [hooks]
+        commit = [
+            { pre = "hook.sh", post = "hook.sh", repo = "vim" },
+            { pre = "hook.sh" }
+        ]
+        "#};
+    let result = cfg_file_mgr.to_string();
+    assert_eq!(expect, result);
+}
+
+#[rstest]
+fn rename_repo_catches_no_repos_section(empty_config_file_fixture: FakeConfigDir) {
+    let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    cfg_file_mgr
+        .read(empty_config_file_fixture.config_file_stub().as_path())
+        .expect("Expect success");
+    let result = cfg_file_mgr.rename_repo("nope", "nada");
+    assert!(matches!(result, Err(RicerError::NoReposSection)));
+}
+
+#[rstest]
+fn rename_repo_catches_inexistent_repo(config_file_fixture: FakeConfigDir) {
+    let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    cfg_file_mgr.read(config_file_fixture.config_file_stub().as_path()).expect("Expect success");
+    let result = cfg_file_mgr.rename_repo("nope", "nada");
+    assert!(matches!(result, Err(RicerError::NoRepoFound { .. })));
+}
+
+#[rstest]
+fn rename_repo_catches_non_table_repos_section(non_table_sections_fixture: FakeConfigDir) {
+    let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    cfg_file_mgr
+        .read(non_table_sections_fixture.config_file_stub().as_path())
+        .expect("Expect success");
+    let result = cfg_file_mgr.rename_repo("nope", "nada");
+    assert!(matches!(result, Err(RicerError::ReposSectionNotTable)));
+}
+
+#[rstest]
 fn get_cmd_hook_deserializes_correctly(config_file_fixture: FakeConfigDir) {
     let mut cfg_file_mgr = DefaultConfigFileManager::new();
     cfg_file_mgr.read(config_file_fixture.config_file_stub().as_path()).expect("Expect success");
@@ -283,7 +335,7 @@ fn get_cmd_hook_deserializes_correctly(config_file_fixture: FakeConfigDir) {
 }
 
 #[rstest]
-fn get_cmd_hook_catches_catches_no_hooks_section(empty_config_file_fixture: FakeConfigDir) {
+fn get_cmd_hook_catches_no_hooks_section(empty_config_file_fixture: FakeConfigDir) {
     let mut cfg_file_mgr = DefaultConfigFileManager::new();
     cfg_file_mgr
         .read(empty_config_file_fixture.config_file_stub().as_path())

--- a/src/tests/file.rs
+++ b/src/tests/file.rs
@@ -196,3 +196,75 @@ fn add_repo_catches_non_table_repos_section(repos_section_not_table_fixture: Fak
     let result = cfg_file_mgr.add_repo(&new_repo);
     assert!(matches!(result, Err(RicerError::ReposSectionNotTable)));
 }
+
+#[rstest]
+fn remove_repo_removes_repo_from_toml_data(config_file_fixture: FakeConfigDir) {
+    let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    cfg_file_mgr
+        .read(config_file_fixture.config_file_stub().as_path())
+        .expect("Expect success");
+    let expect = indoc! {r#"
+
+        # The following should not be overwritten.
+        [hooks]
+        commit = [
+            { pre = "hook.sh", post = "hook.sh", repo = "vim" },
+            { pre = "hook.sh" }
+        ]
+    "#};
+    cfg_file_mgr.remove_repo("vim").expect("Expect success");
+    let result = cfg_file_mgr.to_string();
+    assert_eq!(expect, result);
+}
+
+#[rstest]
+fn remove_repo_provides_correct_repo_data(config_file_fixture: FakeConfigDir) {
+    let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    cfg_file_mgr
+        .read(config_file_fixture.config_file_stub().as_path())
+        .expect("Expect success");
+    let target = RepoTargetEntry::builder()
+        .home(true)
+        .os(TargetOsOption::Unix)
+        .user("awkless")
+        .hostname("lovelace")
+        .build();
+    let expect = RepoEntry::builder("vim")
+        .branch("main")
+        .remote("origin")
+        .url("https://github.com/awkless/vim.git")
+        .target(target)
+        .build();
+    let result = cfg_file_mgr.remove_repo("vim").expect("Expect success");
+    assert_eq!(expect, result);
+}
+
+#[rstest]
+fn remove_repo_catches_no_repos_section(empty_config_file_fixture: FakeConfigDir) {
+    let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    cfg_file_mgr
+        .read(empty_config_file_fixture.config_file_stub().as_path())
+        .expect("Expect success");
+    let result = cfg_file_mgr.remove_repo("nonexistant");
+    assert!(matches!(result, Err(RicerError::NoReposSection)));
+}
+
+#[rstest]
+fn remove_repo_catches_non_table_repos_section(repos_section_not_table_fixture: FakeConfigDir) {
+    let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    cfg_file_mgr
+        .read(repos_section_not_table_fixture.config_file_stub().as_path())
+        .expect("Expect success");
+    let result = cfg_file_mgr.remove_repo("nonexistant");
+    assert!(matches!(result, Err(RicerError::ReposSectionNotTable)));
+}
+
+#[rstest]
+fn remove_repo_catches_inexistent_repo(config_file_fixture: FakeConfigDir) {
+    let mut cfg_file_mgr = DefaultConfigFileManager::new();
+    cfg_file_mgr
+        .read(config_file_fixture.config_file_stub().as_path())
+        .expect("Expect success");
+    let result = cfg_file_mgr.remove_repo("nonexistant");
+    assert!(matches!(result, Err(RicerError::NoRepoFound { .. })));
+}

--- a/src/tests/hooks_section.rs
+++ b/src/tests/hooks_section.rs
@@ -33,9 +33,7 @@ fn deserialize_hook_entry_correctly(toml_doc_fixture: DocumentMut) {
 
     let result = CommandHookEntry::from(hook_entry);
     let mut expect = CommandHookEntry::new("commit");
-    expect.add_hook(
-        HookEntry::builder().pre("hook.sh").post("hook.sh").repo("vim").build(),
-    );
+    expect.add_hook(HookEntry::builder().pre("hook.sh").post("hook.sh").repo("vim").build());
     expect.add_hook(HookEntry::builder().pre("hook.sh").post("hook.sh").build());
     expect.add_hook(HookEntry::builder().post("hook.sh").build());
     assert_eq!(expect, result);

--- a/src/tests/hooks_section.rs
+++ b/src/tests/hooks_section.rs
@@ -34,9 +34,9 @@ fn deserialize_hook_entry_correctly(toml_doc_fixture: DocumentMut) {
     let result = CommandHookEntry::from(hook_entry);
     let mut expect = CommandHookEntry::new("commit");
     expect.add_hook(
-        HookEntry::builder().pre(Some("hook.sh")).post(Some("hook.sh")).repo(Some("vim")).build(),
+        HookEntry::builder().pre("hook.sh").post("hook.sh").repo("vim").build(),
     );
-    expect.add_hook(HookEntry::builder().pre(Some("hook.sh")).post(Some("hook.sh")).build());
-    expect.add_hook(HookEntry::builder().post(Some("hook.sh")).build());
+    expect.add_hook(HookEntry::builder().pre("hook.sh").post("hook.sh").build());
+    expect.add_hook(HookEntry::builder().post("hook.sh").build());
     assert_eq!(expect, result);
 }

--- a/src/tests/repos_section.rs
+++ b/src/tests/repos_section.rs
@@ -71,10 +71,7 @@ fn deserialize_repo_entry_with_missing_target_entry(toml_doc_fixture: DocumentMu
 
 #[rstest]
 fn serialize_repo_entry_correctly(mut toml_doc_fixture: DocumentMut) {
-    let target_entry = RepoTargetEntry::builder()
-        .home(true)
-        .os(TargetOsOption::Windows)
-        .build();
+    let target_entry = RepoTargetEntry::builder().home(true).os(TargetOsOption::Windows).build();
     let repo_entry = RepoEntry::builder("test")
         .branch("master")
         .remote("upstream")

--- a/src/tests/repos_section.rs
+++ b/src/tests/repos_section.rs
@@ -39,8 +39,8 @@ fn deserialize_full_repo_entry(toml_doc_fixture: DocumentMut) {
     let target = RepoTargetEntry::builder()
         .home(true)
         .os(TargetOsOption::Unix)
-        .user(Some("awkless"))
-        .hostname(Some("lovelace"))
+        .user("awkless")
+        .hostname("lovelace")
         .build();
     let expect = RepoEntry::builder("full_entry")
         .branch("master")
@@ -74,8 +74,6 @@ fn serialize_repo_entry_correctly(mut toml_doc_fixture: DocumentMut) {
     let target_entry = RepoTargetEntry::builder()
         .home(true)
         .os(TargetOsOption::Windows)
-        .user(Some("awkless"))
-        .hostname(Some("lovelace"))
         .build();
     let repo_entry = RepoEntry::builder("test")
         .branch("master")
@@ -105,7 +103,7 @@ fn serialize_repo_entry_correctly(mut toml_doc_fixture: DocumentMut) {
         branch = "master"
         remote = "upstream"
         url = "https://github.com/awkless/foobar.git"
-        target = { home = true, os = "windows", user = "awkless", hostname = "lovelace" }
+        target = { home = true, os = "windows" }
         "#
     };
     assert_eq!(expect, result);


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

Implement default configuration file manager to handle Ricer's configuration file.

## Area of Effect

- Module `ricer::config::file`
- Module `ricer::tests`

## Tasks

- [x] Implement `DefaultConfigFileManager::read`
- [x] Implement `DefaultConfigFileManager::write`
- [x] Implement `DefaultConfigFileManager::data`
- [x] Implement `DefaultConfigFileManager::get_repo`
- [x] Implement `DefaultConfigFileManager::add_repo`
- [x] Implement `DefaultConfigFileManager::remove_repo`
- [x] Implement `DefaultConfigFileManager::rename_repo`
- [x] Implement `DefaultConfigFileManager::get_cmd_hook`