### PR TITLE
Remove GPL boilerplate from CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,12 +583,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
-
-[[package]]
 name = "is_debug"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,12 +1081,10 @@ dependencies = [
  "anyhow",
  "clap",
  "clap-verbosity-flag",
- "const_format",
  "dialoguer",
  "directories",
  "env_logger",
  "git2",
- "indoc",
  "log",
  "minus",
  "mkdirp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,12 +34,10 @@ shadow-rs = "0.29"
 anyhow.workspace = true
 clap = { version = "4.5", features = ["derive"] }
 clap-verbosity-flag = "2.2"
-const_format = "0.2"
 dialoguer = "0.11.0"
 directories = "5.0"
 env_logger = "0.11"
 git2.workspace = true
-indoc = "2"
 log = "0.4"
 minus = { version = "5.6", features = [ "static_output", "search" ] }
 mkdirp.workspace = true

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,8 +47,6 @@ use crate::context::commit::FixupAction;
 use crate::context::HookAction;
 use clap::{Args, Parser, Subcommand};
 use clap_verbosity_flag::{InfoLevel, Verbosity};
-use const_format::formatcp;
-use indoc::indoc;
 use std::ffi::OsString;
 
 /// Ricer CLI structure.
@@ -65,7 +63,7 @@ use std::ffi::OsString;
     long_about = None,
     subcommand_help_heading = "Ricer Command Set",
     version,
-    long_version = VERSION_INFORMATION,
+    long_version = build::CLAP_LONG_VERSION,
     term_width = 80
 )]
 pub struct RicerCli {
@@ -273,33 +271,7 @@ pub struct EnterOptions {
     pub repo: String,
 }
 
-const GPL_BOILERPLATE: &str = indoc! {"
-    Copyright (C) 2024 Jason Pena <jasonpena@awkless.com>
-
-    The Ricer program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License as published by the Free
-    Software Foundation; either version 2 of the License, or (at your option) any
-    later version.
-
-    This program also uses the GPL Cooperation Commitment version 1.0 to give itself
-    the cure and reinstatement clauses offered by the GNU GPL version 3 to avoid
-    instant termination of its GPL license for any reported violations.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT
-    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-    FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
-    more details.
-
-    You should have received a copy of the GNU General Public License and the
-    Cooperation Commitment along with Ricer; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-    "
-};
-
-const VERSION_INFORMATION: &str = formatcp!("{}\n\n{GPL_BOILERPLATE}", build::CLAP_LONG_VERSION);
-
-const EXTERNAL_SUBCOMMAND_INFORMATION: &str = indoc! {"
-    Command Shortcuts:
-      <REPO> <GIT_CMD>  Shortcut to execute a Git command directly on a target repository.
-    "
-};
+const EXTERNAL_SUBCOMMAND_INFORMATION: &'static str = r#"
+Command Shortcuts:
+  <REPO> <GIT_CMD>  Shortcut to execute a Git command directly on a target repository.
+"#;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -271,7 +271,7 @@ pub struct EnterOptions {
     pub repo: String,
 }
 
-const EXTERNAL_SUBCOMMAND_INFORMATION: &'static str = r#"
+const EXTERNAL_SUBCOMMAND_INFORMATION: &str = r#"
 Command Shortcuts:
   <REPO> <GIT_CMD>  Shortcut to execute a Git command directly on a target repository.
 "#;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: MIT
 
+mod cli;
+
 // mod default_cfg_dir_locator;
 
 // mod default_cfg_dir_mgr;
 
 // mod default_cfg_file_mgr;
-
-// mod cli;
 
 // mod repo_entry;
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
SPDX-License-Identifier: MIT
-->

## Description

Remove GPL boilerplate from Ricer's CLI, because Ricer was relicensed to MIT.

## Area of Effect

- Module `ricer::cli`.

