### PR TITLE
Simplify `ricer::config` configuration directory locator API

### DIFF
--- a/src/bin/ricer.rs
+++ b/src/bin/ricer.rs
@@ -11,21 +11,8 @@ use log::error;
 use std::ffi::OsString;
 
 use ricer::cli::RicerCli;
-use ricer::config::{
-    DefaultDirLocator, DefaultConfigFileManager, ConfigManager,
-    DefaultConfigDirManager, XdgDirLayout,
-};
 use ricer::context::Context;
-use ricer::error::RicerError;
-use ricer::hook::{CommandHookManager, DefaultCommandHookManager};
 
-/// Starting point of Ricer binary.
-///
-/// # Postconditions
-///
-/// 1. Parse and execute Ricer command set.
-/// 2. Log any errors.
-/// 3. Provide [`ExitCode`] before exiting.
 fn main() {
     std::process::exit(
         match run_ricer(std::env::args_os) {
@@ -39,12 +26,6 @@ fn main() {
     );
 }
 
-/// Run Ricer binary.
-///
-/// # Postconditions
-///
-/// 1. Parse and execute Ricer command set.
-/// 2. Provide [`ExitCode`] after processing.
 fn run_ricer<I, F>(args: F) -> Result<ExitCode>
 where
     I: IntoIterator<Item = OsString>,
@@ -58,27 +39,13 @@ where
         .filter_level(opts.log_opts.log_level_filter())
         .init();
 
-    let ctx = Context::from(opts);
-    let layout = XdgDirLayout::new_layout()?;
-    let locator = DefaultDirLocator::new(&layout);
-    let cfg_dir_mgr = DefaultConfigDirManager::new(&locator);
-    let cfg_file_mgr = DefaultConfigFileManager::new();
-    let mut config = ConfigManager::new(cfg_dir_mgr, cfg_file_mgr);
-    config.read_config_file()?;
-    let hook_mgr = DefaultCommandHookManager::new(&config, &ctx);
-    hook_mgr.run_pre()?;
-
     // TODO: match and execute command in Ricer's command set...
 
     Ok(ExitCode::Success)
 }
 
-/// General exit code status.
 enum ExitCode {
-    /// Ricer binary exited with no errors.
     Success,
-
-    /// Ricer binary exited with errors.
     Failure,
 }
 

--- a/src/bin/ricer.rs
+++ b/src/bin/ricer.rs
@@ -11,12 +11,10 @@ use log::error;
 use std::ffi::OsString;
 
 use ricer::cli::RicerCli;
-use ricer::config::dir::DefaultConfigDirManager;
-use ricer::config::file::DefaultConfigFileManager;
-use ricer::config::locator::{
-    recover_default_config_dir_locator, DefaultConfigDirLocator, DefaultXdgBaseDirSpec,
+use ricer::config::{
+    DefaultDirLocator, DefaultConfigFileManager, ConfigManager,
+    DefaultConfigDirManager, XdgDirLayout,
 };
-use ricer::config::ConfigManager;
 use ricer::context::Context;
 use ricer::error::RicerError;
 use ricer::hook::{CommandHookManager, DefaultCommandHookManager};
@@ -61,12 +59,8 @@ where
         .init();
 
     let ctx = Context::from(opts);
-    let xdg_spec = DefaultXdgBaseDirSpec::new()?;
-    let locator = match DefaultConfigDirLocator::new_locate(&xdg_spec) {
-        Ok(locator) => locator,
-        Err(RicerError::NoConfigDir(..)) => recover_default_config_dir_locator(&xdg_spec)?,
-        Err(err) => return Err(err.into()),
-    };
+    let layout = XdgDirLayout::new_layout()?;
+    let locator = DefaultDirLocator::new(&layout);
     let cfg_dir_mgr = DefaultConfigDirManager::new(&locator);
     let cfg_file_mgr = DefaultConfigFileManager::new();
     let mut config = ConfigManager::new(cfg_dir_mgr, cfg_file_mgr);

--- a/src/bin/ricer.rs
+++ b/src/bin/ricer.rs
@@ -39,6 +39,7 @@ where
         .filter_level(opts.log_opts.log_level_filter())
         .init();
 
+    let _ctx = Context::from(opts);
     // TODO: match and execute command in Ricer's command set...
 
     Ok(ExitCode::Success)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,11 +43,11 @@
 //! external subcommand shortcut to the user.
 
 use crate::build;
-use crate::context::commit::FixupAction;
-use crate::context::HookAction;
 use clap::{Args, Parser, Subcommand};
 use clap_verbosity_flag::{InfoLevel, Verbosity};
 use std::ffi::OsString;
+
+use crate::context::{FixupAction, HookAction};
 
 /// Ricer CLI structure.
 ///

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@
 //! configuration data housed in Ricer's configuration directory. This includes
 //! tracked repositories, hook scripts, ignore files, and configuration files.
 
-use std::path::PathBuf;
+// use std::path::PathBuf;
 
 // mod dir;
 // mod file;

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,405 +9,405 @@
 
 use std::path::PathBuf;
 
-mod dir;
-mod file;
+// mod dir;
+// mod file;
 mod locator;
 
-#[doc(inline)]
-pub use dir::*;
+// #[doc(inline)]
+// pub use dir::*;
 
-#[doc(inline)]
-pub use file::*;
+// #[doc(inline)]
+// pub use file::*;
 
 #[doc(inline)]
 pub use locator::*;
 
-use crate::error::RicerResult;
+//use crate::error::RicerResult;
 
-pub struct ConfigManager<D: ConfigDirManager, F: ConfigFileManager> {
-    dir_manager: D,
-    file_manager: F,
-}
+//pub struct ConfigManager<D: ConfigDirManager, F: ConfigFileManager> {
+//    dir_manager: D,
+//    file_manager: F,
+//}
 
-impl<D, F> ConfigManager<D, F>
-where
-    D: ConfigDirManager,
-    F: ConfigFileManager,
-{
-    /// Construct new configuration manager.
-    ///
-    /// # Preconditions
-    ///
-    /// 1. Valid [`ConfigDirManager`] instance.
-    /// 2. Valid [`ConfigFileManager`] instance.
-    ///
-    /// # Postconditions
-    ///
-    /// 1. Return new configuration manager instance.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use anyhow::Result;
-    /// # fn main() -> Result<()> {
-    /// use ricer::config::dir::{ConfigDirManager, DefaultConfigDirManager};
-    /// use ricer::config::file::DefaultConfigFileManager;
-    /// use ricer::config::locator::{DefaultXdgBaseDirSpec, DefaultConfigDirLocator};
-    /// use ricer::config::ConfigManager;
-    ///
-    /// let xdg_spec = DefaultXdgBaseDirSpec::new()?;
-    /// let locator = DefaultConfigDirLocator::new_locate(&xdg_spec)?;
-    /// let cfg_dir_manager = DefaultConfigDirManager::new(&locator);
-    /// let cfg_file_manager = DefaultConfigFileManager::new();
-    /// let config = ConfigManager::new(cfg_dir_manager, cfg_file_manager);
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
-    /// [`ConfigDirManager`]: crate::config::dir::ConfigDirManager
-    /// [`ConfigFileManager`]: crate::config::file::ConfigFileManager
-    pub fn new(dir_manager: D, file_manager: F) -> Self {
-        Self { dir_manager, file_manager }
-    }
+//impl<D, F> ConfigManager<D, F>
+//where
+//    D: ConfigDirManager,
+//    F: ConfigFileManager,
+//{
+//    /// Construct new configuration manager.
+//    ///
+//    /// # Preconditions
+//    ///
+//    /// 1. Valid [`ConfigDirManager`] instance.
+//    /// 2. Valid [`ConfigFileManager`] instance.
+//    ///
+//    /// # Postconditions
+//    ///
+//    /// 1. Return new configuration manager instance.
+//    ///
+//    /// # Examples
+//    ///
+//    /// ```no_run
+//    /// # use anyhow::Result;
+//    /// # fn main() -> Result<()> {
+//    /// use ricer::config::dir::{ConfigDirManager, DefaultConfigDirManager};
+//    /// use ricer::config::file::DefaultConfigFileManager;
+//    /// use ricer::config::locator::{DefaultXdgBaseDirSpec, DefaultConfigDirLocator};
+//    /// use ricer::config::ConfigManager;
+//    ///
+//    /// let xdg_spec = DefaultXdgBaseDirSpec::new()?;
+//    /// let locator = DefaultConfigDirLocator::new_locate(&xdg_spec)?;
+//    /// let cfg_dir_manager = DefaultConfigDirManager::new(&locator);
+//    /// let cfg_file_manager = DefaultConfigFileManager::new();
+//    /// let config = ConfigManager::new(cfg_dir_manager, cfg_file_manager);
+//    /// # Ok(())
+//    /// # }
+//    /// ```
+//    ///
+//    /// [`ConfigDirManager`]: crate::config::dir::ConfigDirManager
+//    /// [`ConfigFileManager`]: crate::config::file::ConfigFileManager
+//    pub fn new(dir_manager: D, file_manager: F) -> Self {
+//        Self { dir_manager, file_manager }
+//    }
 
-    /// Get reference to configuration directory manager instance.
-    ///
-    /// # Postconditions
-    ///
-    /// 1. Valid reference to configuration directory manager instance.
-    pub fn dir_manager(&self) -> &D {
-        &self.dir_manager
-    }
+//    /// Get reference to configuration directory manager instance.
+//    ///
+//    /// # Postconditions
+//    ///
+//    /// 1. Valid reference to configuration directory manager instance.
+//    pub fn dir_manager(&self) -> &D {
+//        &self.dir_manager
+//    }
 
-    /// Get mutable reference to configuration directory manager instance.
-    ///
-    /// # Postconditions
-    ///
-    /// 1. Valid mutable reference to configuration directory manager instance.
-    pub fn dir_manager_mut(&mut self) -> &mut D {
-        &mut self.dir_manager
-    }
+//    /// Get mutable reference to configuration directory manager instance.
+//    ///
+//    /// # Postconditions
+//    ///
+//    /// 1. Valid mutable reference to configuration directory manager instance.
+//    pub fn dir_manager_mut(&mut self) -> &mut D {
+//        &mut self.dir_manager
+//    }
 
-    /// Get reference to configuration file manager instance.
-    ///
-    /// # Postconditions
-    ///
-    /// 1. Valid reference to configuration file manager instance.
-    pub fn file_manager(&self) -> &F {
-        &self.file_manager
-    }
+//    /// Get reference to configuration file manager instance.
+//    ///
+//    /// # Postconditions
+//    ///
+//    /// 1. Valid reference to configuration file manager instance.
+//    pub fn file_manager(&self) -> &F {
+//        &self.file_manager
+//    }
 
-    /// Get mutable reference to configuration file manager instance.
-    ///
-    /// # Postconditions
-    ///
-    /// 1. Valid mutable reference to configuration file manager instance.
-    pub fn file_manager_mut(&mut self) -> &mut F {
-        &mut self.file_manager
-    }
+//    /// Get mutable reference to configuration file manager instance.
+//    ///
+//    /// # Postconditions
+//    ///
+//    /// 1. Valid mutable reference to configuration file manager instance.
+//    pub fn file_manager_mut(&mut self) -> &mut F {
+//        &mut self.file_manager
+//    }
 
-    /// Read configuration file.
-    ///
-    /// # Preconditions
-    ///
-    /// 1. Configuration file contains valid TOML formatting.
-    ///
-    /// # Postconditions
-    ///
-    /// 1. Read and parse configuration file for later manipulation.
-    ///     - Will create empty configuration file if it does not exist.
-    ///
-    /// # Errors
-    ///
-    /// 1. Will fail if configuration file contains invalid TOML formatting.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use anyhow::Result;
-    /// # fn main() -> Result<()> {
-    /// use ricer::config::dir::{ConfigDirManager, DefaultConfigDirManager};
-    /// use ricer::config::file::DefaultConfigFileManager;
-    /// use ricer::config::locator::{DefaultXdgBaseDirSpec, DefaultConfigDirLocator};
-    /// use ricer::config::ConfigManager;
-    ///
-    /// let xdg_spec = DefaultXdgBaseDirSpec::new()?;
-    /// let locator = DefaultConfigDirLocator::new_locate(&xdg_spec)?;
-    /// let cfg_dir_manager = DefaultConfigDirManager::new(&locator);
-    /// let cfg_file_manager = DefaultConfigFileManager::new();
-    /// let mut config = ConfigManager::new(cfg_dir_manager, cfg_file_manager);
-    /// config.read_config_file()?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
-    /// # See
-    ///
-    /// - [`ConfigDirManager`]
-    /// - [`ConfigFileManager`]
-    ///
-    /// [`ConfigDirManager`]: crate::config::dir::ConfigDirManager
-    /// [`ConfigFileManager`]: crate::config::file::ConfigFileManager
-    pub fn read_config_file(&mut self) -> RicerResult<()> {
-        let path = self.dir_manager.setup_config_file()?;
-        self.file_manager.read(path)?;
-        Ok(())
-    }
+//    /// Read configuration file.
+//    ///
+//    /// # Preconditions
+//    ///
+//    /// 1. Configuration file contains valid TOML formatting.
+//    ///
+//    /// # Postconditions
+//    ///
+//    /// 1. Read and parse configuration file for later manipulation.
+//    ///     - Will create empty configuration file if it does not exist.
+//    ///
+//    /// # Errors
+//    ///
+//    /// 1. Will fail if configuration file contains invalid TOML formatting.
+//    ///
+//    /// # Examples
+//    ///
+//    /// ```no_run
+//    /// # use anyhow::Result;
+//    /// # fn main() -> Result<()> {
+//    /// use ricer::config::dir::{ConfigDirManager, DefaultConfigDirManager};
+//    /// use ricer::config::file::DefaultConfigFileManager;
+//    /// use ricer::config::locator::{DefaultXdgBaseDirSpec, DefaultConfigDirLocator};
+//    /// use ricer::config::ConfigManager;
+//    ///
+//    /// let xdg_spec = DefaultXdgBaseDirSpec::new()?;
+//    /// let locator = DefaultConfigDirLocator::new_locate(&xdg_spec)?;
+//    /// let cfg_dir_manager = DefaultConfigDirManager::new(&locator);
+//    /// let cfg_file_manager = DefaultConfigFileManager::new();
+//    /// let mut config = ConfigManager::new(cfg_dir_manager, cfg_file_manager);
+//    /// config.read_config_file()?;
+//    /// # Ok(())
+//    /// # }
+//    /// ```
+//    ///
+//    /// # See
+//    ///
+//    /// - [`ConfigDirManager`]
+//    /// - [`ConfigFileManager`]
+//    ///
+//    /// [`ConfigDirManager`]: crate::config::dir::ConfigDirManager
+//    /// [`ConfigFileManager`]: crate::config::file::ConfigFileManager
+//    pub fn read_config_file(&mut self) -> RicerResult<()> {
+//        let path = self.dir_manager.setup_config_file()?;
+//        self.file_manager.read(path)?;
+//        Ok(())
+//    }
 
-    /// Write configuration file.
-    ///
-    /// # Postconditions
-    ///
-    /// 1. Write configuration data into configuration file.
-    ///     - If file and/or configuration directory do not exist, then they
-    ///       will be created and written too automatically.
-    /// 2. Preserve original formatting and comments that existed before
-    ///
-    /// # Errors
-    ///
-    /// 1. May fail if it cannot write and/or create the configuration file
-    ///    for whatever reason.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use anyhow::Result;
-    /// # fn main() -> Result<()> {
-    /// use ricer::config::dir::{ConfigDirManager, DefaultConfigDirManager};
-    /// use ricer::config::file::DefaultConfigFileManager;
-    /// use ricer::config::locator::{DefaultXdgBaseDirSpec, DefaultConfigDirLocator};
-    /// use ricer::config::ConfigManager;
-    ///
-    /// let xdg_spec = DefaultXdgBaseDirSpec::new()?;
-    /// let locator = DefaultConfigDirLocator::new_locate(&xdg_spec)?;
-    /// let cfg_dir_manager = DefaultConfigDirManager::new(&locator);
-    /// let cfg_file_manager = DefaultConfigFileManager::new();
-    /// let mut config = ConfigManager::new(cfg_dir_manager, cfg_file_manager);
-    /// config.write_config_file()?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
-    /// # See
-    ///
-    /// - [`ConfigDirManager`]
-    /// - [`ConfigFileManager`]
-    ///
-    /// [`ConfigDirManager`]: crate::config::dir::ConfigDirManager
-    /// [`ConfigFileManager`]: crate::config::file::ConfigFileManager
-    pub fn write_config_file(&mut self) -> RicerResult<()> {
-        let path = self.dir_manager.setup_config_file()?;
-        self.file_manager.write(path)?;
-        Ok(())
-    }
+//    /// Write configuration file.
+//    ///
+//    /// # Postconditions
+//    ///
+//    /// 1. Write configuration data into configuration file.
+//    ///     - If file and/or configuration directory do not exist, then they
+//    ///       will be created and written too automatically.
+//    /// 2. Preserve original formatting and comments that existed before
+//    ///
+//    /// # Errors
+//    ///
+//    /// 1. May fail if it cannot write and/or create the configuration file
+//    ///    for whatever reason.
+//    ///
+//    /// # Examples
+//    ///
+//    /// ```no_run
+//    /// # use anyhow::Result;
+//    /// # fn main() -> Result<()> {
+//    /// use ricer::config::dir::{ConfigDirManager, DefaultConfigDirManager};
+//    /// use ricer::config::file::DefaultConfigFileManager;
+//    /// use ricer::config::locator::{DefaultXdgBaseDirSpec, DefaultConfigDirLocator};
+//    /// use ricer::config::ConfigManager;
+//    ///
+//    /// let xdg_spec = DefaultXdgBaseDirSpec::new()?;
+//    /// let locator = DefaultConfigDirLocator::new_locate(&xdg_spec)?;
+//    /// let cfg_dir_manager = DefaultConfigDirManager::new(&locator);
+//    /// let cfg_file_manager = DefaultConfigFileManager::new();
+//    /// let mut config = ConfigManager::new(cfg_dir_manager, cfg_file_manager);
+//    /// config.write_config_file()?;
+//    /// # Ok(())
+//    /// # }
+//    /// ```
+//    ///
+//    /// # See
+//    ///
+//    /// - [`ConfigDirManager`]
+//    /// - [`ConfigFileManager`]
+//    ///
+//    /// [`ConfigDirManager`]: crate::config::dir::ConfigDirManager
+//    /// [`ConfigFileManager`]: crate::config::file::ConfigFileManager
+//    pub fn write_config_file(&mut self) -> RicerResult<()> {
+//        let path = self.dir_manager.setup_config_file()?;
+//        self.file_manager.write(path)?;
+//        Ok(())
+//    }
 
-    /// Add new repository into configuration data.
-    ///
-    /// # Postconditions
-    ///
-    /// 1. Create new repository directory in `$XDG_CONFIG_HOME/ricer/repos`.
-    ///     - Create sub-directories in path if needed.
-    /// 2. Add repository entry data into configuration file.
-    ///     - Preserve original formatting of configuration file that existed
-    ///       beforehand.
-    ///
-    /// # Errors
-    ///
-    /// 1. Will fail if it cannot insert repository entry into configuration
-    ///    file for whatever reason.
-    /// 2. Will fail if it cannot create the repository in
-    ///    `$XDG_CONFIG_HOME/ricer/repos` for whatever reason.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use anyhow::Result;
-    /// # fn main() -> Result<()> {
-    /// use ricer::config::dir::{ConfigDirManager, DefaultConfigDirManager};
-    /// use ricer::config::file::repos_section::RepoEntry;
-    /// use ricer::config::file::DefaultConfigFileManager;
-    /// use ricer::config::locator::{DefaultXdgBaseDirSpec, DefaultConfigDirLocator};
-    /// use ricer::config::ConfigManager;
-    ///
-    /// let xdg_spec = DefaultXdgBaseDirSpec::new()?;
-    /// let locator = DefaultConfigDirLocator::new_locate(&xdg_spec)?;
-    /// let cfg_dir_manager = DefaultConfigDirManager::new(&locator);
-    /// let cfg_file_manager = DefaultConfigFileManager::new();
-    /// let mut config = ConfigManager::new(cfg_dir_manager, cfg_file_manager);
-    /// config.read_config_file()?;
-    /// let new_repo = RepoEntry::builder("vim")
-    ///     .branch("main")
-    ///     .remote("master")
-    ///     .url("https://github.com/awkless/vim.git")
-    ///     .build();
-    /// config.add_repo(&new_repo)?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
-    /// # See
-    ///
-    /// - [`ConfigDirManager`]
-    /// - [`ConfigFileManager`]
-    ///
-    /// [`ConfigDirManager`]: crate::config::dir::ConfigDirManager
-    /// [`ConfigFileManager`]: crate::config::file::ConfigFileManager
-    pub fn add_repo(&mut self, repo_entry: &RepoEntry) -> RicerResult<()> {
-        self.dir_manager.add_repo(&repo_entry.name)?;
-        self.file_manager.add_repo(repo_entry)?;
-        Ok(())
-    }
+//    /// Add new repository into configuration data.
+//    ///
+//    /// # Postconditions
+//    ///
+//    /// 1. Create new repository directory in `$XDG_CONFIG_HOME/ricer/repos`.
+//    ///     - Create sub-directories in path if needed.
+//    /// 2. Add repository entry data into configuration file.
+//    ///     - Preserve original formatting of configuration file that existed
+//    ///       beforehand.
+//    ///
+//    /// # Errors
+//    ///
+//    /// 1. Will fail if it cannot insert repository entry into configuration
+//    ///    file for whatever reason.
+//    /// 2. Will fail if it cannot create the repository in
+//    ///    `$XDG_CONFIG_HOME/ricer/repos` for whatever reason.
+//    ///
+//    /// # Examples
+//    ///
+//    /// ```no_run
+//    /// # use anyhow::Result;
+//    /// # fn main() -> Result<()> {
+//    /// use ricer::config::dir::{ConfigDirManager, DefaultConfigDirManager};
+//    /// use ricer::config::file::repos_section::RepoEntry;
+//    /// use ricer::config::file::DefaultConfigFileManager;
+//    /// use ricer::config::locator::{DefaultXdgBaseDirSpec, DefaultConfigDirLocator};
+//    /// use ricer::config::ConfigManager;
+//    ///
+//    /// let xdg_spec = DefaultXdgBaseDirSpec::new()?;
+//    /// let locator = DefaultConfigDirLocator::new_locate(&xdg_spec)?;
+//    /// let cfg_dir_manager = DefaultConfigDirManager::new(&locator);
+//    /// let cfg_file_manager = DefaultConfigFileManager::new();
+//    /// let mut config = ConfigManager::new(cfg_dir_manager, cfg_file_manager);
+//    /// config.read_config_file()?;
+//    /// let new_repo = RepoEntry::builder("vim")
+//    ///     .branch("main")
+//    ///     .remote("master")
+//    ///     .url("https://github.com/awkless/vim.git")
+//    ///     .build();
+//    /// config.add_repo(&new_repo)?;
+//    /// # Ok(())
+//    /// # }
+//    /// ```
+//    ///
+//    /// # See
+//    ///
+//    /// - [`ConfigDirManager`]
+//    /// - [`ConfigFileManager`]
+//    ///
+//    /// [`ConfigDirManager`]: crate::config::dir::ConfigDirManager
+//    /// [`ConfigFileManager`]: crate::config::file::ConfigFileManager
+//    pub fn add_repo(&mut self, repo_entry: &RepoEntry) -> RicerResult<()> {
+//        self.dir_manager.add_repo(&repo_entry.name)?;
+//        self.file_manager.add_repo(repo_entry)?;
+//        Ok(())
+//    }
 
-    /// Get repository data from configuration file and `$XDG_CONFIG_HOME/ricer/repos`.
-    ///
-    /// # Preconditions
-    ///
-    /// 1. Repository exists in configuration file.
-    /// 2. Repository exists in `$XDG_CONFIG_HOME/ricer/repos`.
-    ///
-    /// # Postconditions
-    ///
-    /// 1. Return path to target repository.
-    /// 2. Return configuration file entry data of repository.
-    ///
-    /// # Errors
-    ///
-    /// 1. Will fail if repository entry does not exist in configuration file.
-    /// 2. Will fail if repository entry does not exist in
-    ///    `$XDG_CONFIG_HOME/ricer/repos`.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use anyhow::Result;
-    /// # fn main() -> Result<()> {
-    /// use ricer::config::dir::{ConfigDirManager, DefaultConfigDirManager};
-    /// use ricer::config::file::DefaultConfigFileManager;
-    /// use ricer::config::locator::{DefaultXdgBaseDirSpec, DefaultConfigDirLocator};
-    /// use ricer::config::ConfigManager;
-    ///
-    /// let xdg_spec = DefaultXdgBaseDirSpec::new()?;
-    /// let locator = DefaultConfigDirLocator::new_locate(&xdg_spec)?;
-    /// let cfg_dir_manager = DefaultConfigDirManager::new(&locator);
-    /// let cfg_file_manager = DefaultConfigFileManager::new();
-    /// let mut config = ConfigManager::new(cfg_dir_manager, cfg_file_manager);
-    /// config.read_config_file()?;
-    /// let (path, repo) = config.get_repo("vim")?;
-    /// println!("{} - {:#?}", path.display(), repo);
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
-    /// # See
-    ///
-    /// - [`ConfigDirManager`]
-    /// - [`ConfigFileManager`]
-    ///
-    /// [`ConfigDirManager`]: crate::config::dir::ConfigDirManager
-    /// [`ConfigFileManager`]: crate::config::file::ConfigFileManager
-    pub fn get_repo(&self, name: impl AsRef<str>) -> RicerResult<(PathBuf, RepoEntry)> {
-        let path = self.dir_manager.get_repo(name.as_ref())?;
-        let repo = self.file_manager.get_repo(name.as_ref())?;
-        Ok((path, repo))
-    }
+//    /// Get repository data from configuration file and `$XDG_CONFIG_HOME/ricer/repos`.
+//    ///
+//    /// # Preconditions
+//    ///
+//    /// 1. Repository exists in configuration file.
+//    /// 2. Repository exists in `$XDG_CONFIG_HOME/ricer/repos`.
+//    ///
+//    /// # Postconditions
+//    ///
+//    /// 1. Return path to target repository.
+//    /// 2. Return configuration file entry data of repository.
+//    ///
+//    /// # Errors
+//    ///
+//    /// 1. Will fail if repository entry does not exist in configuration file.
+//    /// 2. Will fail if repository entry does not exist in
+//    ///    `$XDG_CONFIG_HOME/ricer/repos`.
+//    ///
+//    /// # Examples
+//    ///
+//    /// ```no_run
+//    /// # use anyhow::Result;
+//    /// # fn main() -> Result<()> {
+//    /// use ricer::config::dir::{ConfigDirManager, DefaultConfigDirManager};
+//    /// use ricer::config::file::DefaultConfigFileManager;
+//    /// use ricer::config::locator::{DefaultXdgBaseDirSpec, DefaultConfigDirLocator};
+//    /// use ricer::config::ConfigManager;
+//    ///
+//    /// let xdg_spec = DefaultXdgBaseDirSpec::new()?;
+//    /// let locator = DefaultConfigDirLocator::new_locate(&xdg_spec)?;
+//    /// let cfg_dir_manager = DefaultConfigDirManager::new(&locator);
+//    /// let cfg_file_manager = DefaultConfigFileManager::new();
+//    /// let mut config = ConfigManager::new(cfg_dir_manager, cfg_file_manager);
+//    /// config.read_config_file()?;
+//    /// let (path, repo) = config.get_repo("vim")?;
+//    /// println!("{} - {:#?}", path.display(), repo);
+//    /// # Ok(())
+//    /// # }
+//    /// ```
+//    ///
+//    /// # See
+//    ///
+//    /// - [`ConfigDirManager`]
+//    /// - [`ConfigFileManager`]
+//    ///
+//    /// [`ConfigDirManager`]: crate::config::dir::ConfigDirManager
+//    /// [`ConfigFileManager`]: crate::config::file::ConfigFileManager
+//    pub fn get_repo(&self, name: impl AsRef<str>) -> RicerResult<(PathBuf, RepoEntry)> {
+//        let path = self.dir_manager.get_repo(name.as_ref())?;
+//        let repo = self.file_manager.get_repo(name.as_ref())?;
+//        Ok((path, repo))
+//    }
 
-    /// Remove Git repository from configuration data.
-    ///
-    /// # Postconditions
-    ///
-    /// 1. Remove Git repository directory entry from `$XDG_CONFIG_HOME/ricer/repos`.
-    ///     - Will not fail if repository directory entry does not exist.
-    /// 2. Remove configuration file repository entry.
-    ///     - Will not fail if repository entry does not exist.
-    ///
-    /// # Errors
-    ///
-    /// 1. Will fail if repository entry in `$XDG_CONFIG_HOME/ricer/repos`
-    ///    cannot be deleted.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use anyhow::Result;
-    /// # fn main() -> Result<()> {
-    /// use ricer::config::dir::{ConfigDirManager, DefaultConfigDirManager};
-    /// use ricer::config::file::DefaultConfigFileManager;
-    /// use ricer::config::locator::{DefaultXdgBaseDirSpec, DefaultConfigDirLocator};
-    /// use ricer::config::ConfigManager;
-    ///
-    /// let xdg_spec = DefaultXdgBaseDirSpec::new()?;
-    /// let locator = DefaultConfigDirLocator::new_locate(&xdg_spec)?;
-    /// let cfg_dir_manager = DefaultConfigDirManager::new(&locator);
-    /// let cfg_file_manager = DefaultConfigFileManager::new();
-    /// let mut config = ConfigManager::new(cfg_dir_manager, cfg_file_manager);
-    /// config.read_config_file()?;
-    /// config.remove_repo("vim")?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
-    /// # See
-    ///
-    /// - [`ConfigDirManager`]
-    /// - [`ConfigFileManager`]
-    ///
-    /// [`ConfigDirManager`]: crate::config::dir::ConfigDirManager
-    /// [`ConfigFileManager`]: crate::config::file::ConfigFileManager
-    pub fn remove_repo(&mut self, repo_name: impl AsRef<str>) -> RicerResult<()> {
-        self.dir_manager.remove_repo(repo_name.as_ref())?;
-        self.file_manager.remove_repo(repo_name.as_ref())?;
-        Ok(())
-    }
+//    /// Remove Git repository from configuration data.
+//    ///
+//    /// # Postconditions
+//    ///
+//    /// 1. Remove Git repository directory entry from `$XDG_CONFIG_HOME/ricer/repos`.
+//    ///     - Will not fail if repository directory entry does not exist.
+//    /// 2. Remove configuration file repository entry.
+//    ///     - Will not fail if repository entry does not exist.
+//    ///
+//    /// # Errors
+//    ///
+//    /// 1. Will fail if repository entry in `$XDG_CONFIG_HOME/ricer/repos`
+//    ///    cannot be deleted.
+//    ///
+//    /// # Examples
+//    ///
+//    /// ```no_run
+//    /// # use anyhow::Result;
+//    /// # fn main() -> Result<()> {
+//    /// use ricer::config::dir::{ConfigDirManager, DefaultConfigDirManager};
+//    /// use ricer::config::file::DefaultConfigFileManager;
+//    /// use ricer::config::locator::{DefaultXdgBaseDirSpec, DefaultConfigDirLocator};
+//    /// use ricer::config::ConfigManager;
+//    ///
+//    /// let xdg_spec = DefaultXdgBaseDirSpec::new()?;
+//    /// let locator = DefaultConfigDirLocator::new_locate(&xdg_spec)?;
+//    /// let cfg_dir_manager = DefaultConfigDirManager::new(&locator);
+//    /// let cfg_file_manager = DefaultConfigFileManager::new();
+//    /// let mut config = ConfigManager::new(cfg_dir_manager, cfg_file_manager);
+//    /// config.read_config_file()?;
+//    /// config.remove_repo("vim")?;
+//    /// # Ok(())
+//    /// # }
+//    /// ```
+//    ///
+//    /// # See
+//    ///
+//    /// - [`ConfigDirManager`]
+//    /// - [`ConfigFileManager`]
+//    ///
+//    /// [`ConfigDirManager`]: crate::config::dir::ConfigDirManager
+//    /// [`ConfigFileManager`]: crate::config::file::ConfigFileManager
+//    pub fn remove_repo(&mut self, repo_name: impl AsRef<str>) -> RicerResult<()> {
+//        self.dir_manager.remove_repo(repo_name.as_ref())?;
+//        self.file_manager.remove_repo(repo_name.as_ref())?;
+//        Ok(())
+//    }
 
-    /// Rename repository in configuration data.
-    ///
-    /// # Preconditions
-    ///
-    /// 1. Repository entry exists in configuration file.
-    /// 2. Repository directory entry exists in `$XDG_CONFIG_HOME/ricer/repos`.
-    ///
-    /// # Postconditions
-    ///
-    /// 1. Rename repository entry in `$XDG_CONFIG_HOME/ricer/repos`.
-    /// 2. Rename repository entry in configuration file.
-    ///
-    /// # Errors
-    ///
-    /// 1. Will fail if repository entry does not exist in configuration file.
-    /// 2. Will fail if repository directory cannot be renamed in
-    ///    `$XDG_CONFIG_HOME/ricer/repos`.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use anyhow::Result;
-    /// # fn main() -> Result<()> {
-    /// use ricer::config::dir::{ConfigDirManager, DefaultConfigDirManager};
-    /// use ricer::config::file::DefaultConfigFileManager;
-    /// use ricer::config::locator::{DefaultXdgBaseDirSpec, DefaultConfigDirLocator};
-    /// use ricer::config::ConfigManager;
-    ///
-    /// let xdg_spec = DefaultXdgBaseDirSpec::new()?;
-    /// let locator = DefaultConfigDirLocator::new_locate(&xdg_spec)?;
-    /// let cfg_dir_manager = DefaultConfigDirManager::new(&locator);
-    /// let cfg_file_manager = DefaultConfigFileManager::new();
-    /// let mut config = ConfigManager::new(cfg_dir_manager, cfg_file_manager);
-    /// config.read_config_file()?;
-    /// config.rename_repo("vim", "vimrc")?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
-    /// # See
-    ///
-    /// - [`ConfigDirManager`]
-    /// - [`ConfigFileManager`]
-    ///
-    /// [`ConfigDirManager`]: crate::config::dir::ConfigDirManager
-    /// [`ConfigFileManager`]: crate::config::file::ConfigFileManager
-    pub fn rename_repo(&mut self, from: impl AsRef<str>, to: impl AsRef<str>) -> RicerResult<()> {
-        self.dir_manager.rename_repo(from.as_ref(), to.as_ref())?;
-        self.file_manager.rename_repo(from.as_ref(), to.as_ref())?;
-        Ok(())
-    }
-}
+//    /// Rename repository in configuration data.
+//    ///
+//    /// # Preconditions
+//    ///
+//    /// 1. Repository entry exists in configuration file.
+//    /// 2. Repository directory entry exists in `$XDG_CONFIG_HOME/ricer/repos`.
+//    ///
+//    /// # Postconditions
+//    ///
+//    /// 1. Rename repository entry in `$XDG_CONFIG_HOME/ricer/repos`.
+//    /// 2. Rename repository entry in configuration file.
+//    ///
+//    /// # Errors
+//    ///
+//    /// 1. Will fail if repository entry does not exist in configuration file.
+//    /// 2. Will fail if repository directory cannot be renamed in
+//    ///    `$XDG_CONFIG_HOME/ricer/repos`.
+//    ///
+//    /// # Examples
+//    ///
+//    /// ```no_run
+//    /// # use anyhow::Result;
+//    /// # fn main() -> Result<()> {
+//    /// use ricer::config::dir::{ConfigDirManager, DefaultConfigDirManager};
+//    /// use ricer::config::file::DefaultConfigFileManager;
+//    /// use ricer::config::locator::{DefaultXdgBaseDirSpec, DefaultConfigDirLocator};
+//    /// use ricer::config::ConfigManager;
+//    ///
+//    /// let xdg_spec = DefaultXdgBaseDirSpec::new()?;
+//    /// let locator = DefaultConfigDirLocator::new_locate(&xdg_spec)?;
+//    /// let cfg_dir_manager = DefaultConfigDirManager::new(&locator);
+//    /// let cfg_file_manager = DefaultConfigFileManager::new();
+//    /// let mut config = ConfigManager::new(cfg_dir_manager, cfg_file_manager);
+//    /// config.read_config_file()?;
+//    /// config.rename_repo("vim", "vimrc")?;
+//    /// # Ok(())
+//    /// # }
+//    /// ```
+//    ///
+//    /// # See
+//    ///
+//    /// - [`ConfigDirManager`]
+//    /// - [`ConfigFileManager`]
+//    ///
+//    /// [`ConfigDirManager`]: crate::config::dir::ConfigDirManager
+//    /// [`ConfigFileManager`]: crate::config::file::ConfigFileManager
+//    pub fn rename_repo(&mut self, from: impl AsRef<str>, to: impl AsRef<str>) -> RicerResult<()> {
+//        self.dir_manager.rename_repo(from.as_ref(), to.as_ref())?;
+//        self.file_manager.rename_repo(from.as_ref(), to.as_ref())?;
+//        Ok(())
+//    }
+//}

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,14 +9,20 @@
 
 use std::path::PathBuf;
 
-pub mod dir;
-pub mod file;
-pub mod locator;
+mod dir;
+mod file;
+mod locator;
+
+#[doc(inline)]
+pub use dir::*;
+
+#[doc(inline)]
+pub use file::*;
+
+#[doc(inline)]
+pub use locator::*;
 
 use crate::error::RicerResult;
-use dir::ConfigDirManager;
-use file::repos_section::RepoEntry;
-use file::ConfigFileManager;
 
 pub struct ConfigManager<D: ConfigDirManager, F: ConfigFileManager> {
     dir_manager: D,

--- a/src/config/dir.rs
+++ b/src/config/dir.rs
@@ -55,7 +55,7 @@ use log::{debug, trace, warn};
 use std::fs::{create_dir_all, read_to_string, remove_dir_all, rename, write, File};
 use std::path::{Path, PathBuf};
 
-use crate::config::locator::ConfigDirLocator;
+use crate::config::DirLocator;
 use crate::error::RicerResult;
 
 /// Configuration directory manager representation.
@@ -126,18 +126,17 @@ impl DefaultConfigDirManager {
     /// ```no_run
     /// # use anyhow::Result;
     /// # fn main() -> Result<()> {
-    /// use ricer::config::locator::{DefaultXdgBaseDirSpec, DefaultConfigDirLocator};
-    /// use ricer::config::dir::DefaultConfigDirManager;
+    /// use ricer::config::{DefaultDirLocator, XdgDirLayout, DefaultConfigDirManager};
     ///
-    /// let xdg_spec = DefaultXdgBaseDirSpec::new()?;
-    /// let locator = DefaultConfigDirLocator::new_locate(&xdg_spec)?;
+    /// let layout = XdgDirLayout::new_layout()?;
+    /// let locator = DefaultDirLocator::new_locate(&xdg_spec)?;
     /// let cfg_dir_mgr = DefaultConfigDirManager::new(&locator);
     /// # Ok(())
     /// # }
     /// ```
     ///
     /// [`ConfigDirLocator`]: crate::config::locator::ConfigDirLocator
-    pub fn new(locator: &dyn ConfigDirLocator) -> Self {
+    pub fn new(locator: &dyn DirLocator) -> Self {
         trace!("Construct default configuration directory manager");
         let root_dir = locator.config_dir().to_path_buf();
         let repos_dir = root_dir.join("repos");

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -19,12 +19,16 @@ use std::fs::{read_to_string, write};
 use std::path::Path;
 use toml_edit::{DocumentMut, Item, Key, Table};
 
-pub mod hooks_section;
-pub mod repos_section;
+mod hooks_section;
+mod repos_section;
+
+#[doc(inline)]
+pub use hooks_section::*;
+
+#[doc(inline)]
+pub use repos_section::*;
 
 use crate::error::RicerResult;
-use hooks_section::CommandHookEntry;
-use repos_section::RepoEntry;
 
 /// Configuration file manager representation.
 pub trait ConfigFileManager: Display {

--- a/src/config/locator.rs
+++ b/src/config/locator.rs
@@ -1,245 +1,103 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: MIT
 
-//! Locate configuration directory.
+//! Locate configuration directories.
 //!
-//! Basic way to locate Ricer's configuration directory at an expected area in
-//! the user's environment. This logic remains seperate from configuration
-//! directory management logic to make it easier to change the expected location
-//! of Ricer's configuration directory at any time if need be. By default Ricer
-//! expects its configuration directory to be at `$XDG_CONFIG_HOME/ricer`, i.e.,
-//! `$HOME/.config/ricer`.
+//! Ricer uses three configuration directories:
+//!
+//! 1. Configuration file directory housing configuration file data at
+//!    `$XDG_CONFIG_HOME/ricer`.
+//! 2. Hook script directory housing executable hook scripts at
+//!    `$XDG_CONFIG_HOME/ricer/hooks`.
+//! 3. Repository directory housing tracked repository data at
+//!    `XDG_DATA_HOME/ricer`.
+//!
+//! This modules determines absolute paths to all three of Ricer's configuration
+//! directories for later manipulation in the codebase. This module only
+//! determines the _expected_ locations for each configuration directory,
+//! __not__ whether any one of them actually exists. The job of existence
+//! verification is left to the various configuration manager implementations in
+//! Ricer's codebase.
 
-use anyhow::anyhow;
-use directories::BaseDirs;
-use log::{debug, trace, warn};
-use std::fs::create_dir;
+use log::{debug, trace};
 use std::path::{Path, PathBuf};
 
 #[cfg(test)]
 use mockall::automock;
 
-use crate::error::{RicerError, RicerResult};
+mod layout;
+
+#[doc(inline)]
+pub use layout::*;
 
 /// Configuration directory locator representation.
 #[cfg_attr(test, automock)]
-pub trait ConfigDirLocator {
-    /// Provide absolute path to located configuration directory.
+pub trait DirLocator {
+    /// Expected absolute path to configuration file directory.
     fn config_dir(&self) -> &Path;
+
+    /// Expected absolute path to hook script directory.
+    fn hooks_dir(&self) -> &Path;
+
+    /// Expected absolute path to repository directory.
+    fn repos_dir(&self) -> &Path;
 }
 
-/// [XDG Base Directory][xdg-base-dir-spec] representation.
-///
-/// [xdg-base-dir-spec]: https://wiki.archlinux.org/title/XDG_Base_Directory
-#[cfg_attr(test, automock)]
-pub trait XdgBaseDirSpec {
-    /// Absolute path of `$XDG_CONFIG_HOME`.
-    fn config_home_dir(&self) -> &Path;
-}
-
-/// Default implementation of [`XdgBaseDirSpec`].
-pub struct DefaultXdgBaseDirSpec {
-    xdg_spec: BaseDirs,
-}
-
-impl DefaultXdgBaseDirSpec {
-    /// Construct new instance of default XDG Base Directory Specification
-    /// handler.
-    ///
-    /// # Postconditions
-    ///
-    /// 1. Return Default XDG Base Directory Specification handler instance.
-    ///
-    /// # Errors
-    ///
-    /// Issues [`RicerError::Unrecoverable`] if it cannot determine home
-    /// directory of user.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use anyhow::Result;
-    /// # fn main() -> Result<()> {
-    /// use ricer::config::locator::{DefaultXdgBaseDirSpec, XdgBaseDirSpec};
-    ///
-    /// let xdg_spec = DefaultXdgBaseDirSpec::new()?;
-    /// println!("{}", xdg_spec.config_home_dir().display());
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
-    /// # See
-    ///
-    /// - <https://docs.rs/directories/latest/directories/struct.BaseDirs.html#method.new>
-    pub fn new() -> RicerResult<Self> {
-        trace!("Construct default XDG Base Directory Specification handler");
-        let xdg_spec = BaseDirs::new().ok_or(RicerError::Unrecoverable(anyhow!(
-            "Failed to locate configuration directory"
-        )))?;
-
-        Ok(Self { xdg_spec })
-    }
-}
-
-impl XdgBaseDirSpec for DefaultXdgBaseDirSpec {
-    /// Get path of `$XDG_CONFIG_HOME`.
-    ///
-    /// # Postconditions
-    ///
-    /// 1. Return path of `$XDG_CONFIG_HOME`.
-    ///
-    /// # Invariants
-    ///
-    /// 1. Returned path is guaranteed to be absolute.
-    ///
-    fn config_home_dir(&self) -> &Path {
-        let path = self.xdg_spec.config_dir();
-        debug_assert!(path.is_absolute(), "Path of $XDG_CONFIG_HOME is not absolute");
-        path
-    }
-}
-
-/// Configuration directory locatory following XDG base directory specification.
-///
-/// Attempts to locate Ricer's configuration directory using an implementation
-/// of [`XdgBaseDirSpec`]. Expects the configuration directory to be at
-/// `$XDG_CONFIG_HOME/ricer`.
-///
-/// # Invariants
-///
-/// 1. Locator provides an absolute path to configuration directory.
-pub struct DefaultConfigDirLocator {
+/// Default configuration directory locator.
+pub struct DefaultDirLocator {
     config_dir: PathBuf,
+    hooks_dir: PathBuf,
+    repos_dir: PathBuf,
 }
 
-impl DefaultConfigDirLocator {
-    /// Construct new default configuration directory locator.
+impl DefaultDirLocator {
+    /// Construct default configuration directory locator.
     ///
-    /// This method will construct a new instance of [`DefaultConfigDirLocator`]
-    /// that automatically locates the expected absolute path to Ricer's
-    /// configuration directory at `$XDG_CONFIG_HOME/ricer` using an
-    /// implementation of [`XdgBaseDirSpec`].
-    ///
-    /// # Preconditions
-    ///
-    /// 1. Valid instance of [`XdgBaseDirSpec`].
-    ///
-    /// # Postconditions
-    ///
-    /// 1. Return new default configuration directory locator instance.
-    ///
-    /// # Invariants
-    ///
-    /// 1. Located path to configuration directory is absolute.
-    ///
-    /// # Errors
-    ///
-    /// Issues [`RicerError::NoConfigDir`] if configuration directory does not
-    /// exist at `$XDG_CONFIG_HOME/ricer`.
+    /// Will locate _expected_ absolute paths to Ricer's configuration
+    /// directory, hook script directory, and repository directory.
     ///
     /// # Examples
     ///
     /// ```no_run
     /// # use anyhow::Result;
     /// # fn main() -> Result<()> {
-    /// use ricer::config::locator::{DefaultXdgBaseDirSpec, DefaultConfigDirLocator};
-    /// use ricer::error::RicerError;
+    /// use std::env;
+    /// use std::path::PathBuf;
     ///
-    /// let xdg_spec = DefaultXdgBaseDirSpec::new()?;
-    /// let locator = match DefaultConfigDirLocator::new_locate(&xdg_spec) {
-    ///     Ok(locator) => locator,
-    ///     Err(RicerError::NoConfigDir(..)) => {
-    ///         // TODO: Recovery logic...
-    ///         todo!();
-    ///     }
-    ///     Err(err) => return Err(err.into()),
-    /// };
+    /// use ricer::config::{DirLocator, DefaultDirLocator, XdgDirLayout};
+    ///
+    /// let home = env::var("HOME")?;
+    /// let layout = XdgDirLayout::new_layout()?;
+    /// let locator = DefaultDirLocator::new_locate(&layout);
+    /// assert_eq!(locator.config_dir(), PathBuf::from(format!("{}/ricer", home)).as_path());
+    /// assert_eq!(locator.hooks_dir(), PathBuf::from(format!("{}/ricer/hooks", home)).as_path());
+    /// assert_eq!(locator.repos_dir(), PathBuf::from(format!("{}/ricer", home)).as_path());
     /// # Ok(())
     /// # }
     /// ```
-    ///
-    /// [`RicerError::NoConfigDir`]: crate::error::RicerError::NoConfigDir
-    pub fn new_locate(xdg_spec: &dyn XdgBaseDirSpec) -> RicerResult<Self> {
-        trace!("Construct default configuration directory locator");
-        let config_dir = xdg_spec.config_home_dir().join("ricer");
-        debug_assert!(config_dir.is_absolute(), "Path to $XDG_CONFIG_HOME/ricer is not absolute");
-        if !config_dir.exists() {
-            return Err(RicerError::NoConfigDir(anyhow!(
-                "Expected configuration directory at '{}'",
-                config_dir.display()
-            )));
-        }
+    pub fn new_locate(layout: &impl DirLayout) -> Self {
+        trace!("Construct configuration directory locator");
+        let config_dir = layout.config_dir().join("ricer");
+        let hooks_dir = config_dir.join("hooks");
+        let repos_dir = layout.data_dir().join("ricer_repos");
 
         debug!("Configuration directory located at '{}'", config_dir.display());
-        Ok(Self { config_dir })
+        debug!("Hook script directory located at '{}'", hooks_dir.display());
+        debug!("Repository directory located at '{}'", repos_dir.display());
+        Self { config_dir, hooks_dir, repos_dir }
     }
 }
 
-impl ConfigDirLocator for DefaultConfigDirLocator {
-    /// Get located path to configuration directory.
-    ///
-    /// # Postconditions
-    ///
-    /// 1. Return path of `$XDG_CONFIG_HOME/ricer`.
-    ///
-    /// # Invariants
-    ///
-    /// 1. Returned path is guaranteed to be absolute.
+impl DirLocator for DefaultDirLocator {
     fn config_dir(&self) -> &Path {
         self.config_dir.as_path()
     }
-}
 
-/// Recovery logic for [`DefaultConfigDirLocator`].
-///
-/// Creates the configuration directory at expected location provided by
-/// [`XdgBaseDirSpec`] as a recovery strategy.
-///
-/// # Preconditions
-///
-/// 1. Valid instance of [`XdgBaseDirSpec`].
-///
-/// # Postconditions
-///
-/// 1. Return instance of [`DefaultConfigDirLocator`].
-///
-/// # Errors
-///
-/// Cannot create the configuration directory at expected path.
-///
-/// # Examples
-///
-/// ```no_run
-/// # use anyhow::Result;
-/// # fn main() -> Result<()> {
-/// use ricer::config::locator::{
-///     recover_default_config_dir_locator, DefaultXdgBaseDirSpec, DefaultConfigDirLocator
-/// };
-/// use ricer::error::RicerError;
-///
-/// let xdg_spec = DefaultXdgBaseDirSpec::new()?;
-/// let locator = match DefaultConfigDirLocator::new_locate(&xdg_spec) {
-///     Ok(locator) => locator,
-///     Err(RicerError::NoConfigDir(..)) => recover_default_config_dir_locator(&xdg_spec)?,
-///     Err(err) => return Err(err.into()),
-/// };
-/// # Ok(())
-/// # }
-/// ```
-///
-/// # See
-///
-/// - <https://doc.rust-lang.org/std/fs/fn.create_dir.html#errors>
-///
-/// [`RicerError::NoConfigDir`]: crate::error::RicerError::NoConfigDir
-pub fn recover_default_config_dir_locator(
-    xdg_spec: &dyn XdgBaseDirSpec,
-) -> RicerResult<DefaultConfigDirLocator> {
-    let config_dir = xdg_spec.config_home_dir().join("ricer");
+    fn hooks_dir(&self) -> &Path {
+        self.hooks_dir.as_path()
+    }
 
-    warn!("Creating configuration directory since it does not exist at '{}'", config_dir.display());
-    create_dir(config_dir)?;
-
-    let locator = DefaultConfigDirLocator::new_locate(xdg_spec)?;
-    Ok(locator)
+    fn repos_dir(&self) -> &Path {
+        self.repos_dir.as_path()
+    }
 }

--- a/src/config/locator/layout.rs
+++ b/src/config/locator/layout.rs
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
-// SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
+// SPDX-License-Identifier: MIT
 
 //! Handle different configuration directory layouts.
 //!

--- a/src/config/locator/layout.rs
+++ b/src/config/locator/layout.rs
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: GPL-2.0-or-later WITH GPL-CC-1.0
+
+//! Handle different configuration directory layouts.
+//!
+//! At a high level of abstraction, Ricer mainly splits its configuration
+//! directories into two categories: configuration file, and configuration data.
+//! The configuration file category houses all files that configure Ricer's
+//! behavior, while the configuration data category contains data that Ricer
+//! needs to keep track of and manipulate.
+//!
+//! This module provides a standard way to organize the layout of both
+//! categories. Mainly by providing a one-to-one mapping with the
+//! [XDG Base Directory Specification][xdg] in order to make the layout more
+//! predictable.
+//!
+//! [xdg]: https://specifications.freedesktop.org/basedir-spec/latest/
+
+use anyhow::{anyhow, Result};
+use directories::BaseDirs;
+use log::trace;
+use std::path::Path;
+
+#[cfg(test)]
+use mockall::automock;
+
+/// Configuration directory layout representation.
+#[cfg_attr(test, automock)]
+pub trait DirLayout {
+    /// Absolute path to directory where configuration files will be stored.
+    fn config_dir(&self) -> &Path;
+
+    /// Absolute path to directory where configuration data will be stored.
+    fn data_dir(&self) -> &Path;
+}
+
+/// Configuration directory layout handler following [XDG Base Directory
+/// Specification][xdg].
+///
+/// [xdg]: https://specifications.freedesktop.org/basedir-spec/latest/
+pub struct XdgDirLayout {
+    xdg_spec: BaseDirs,
+}
+
+impl XdgDirLayout {
+    /// Construct new XDG configuration directory layout handler.
+    ///
+    /// # Errors
+    ///
+    /// Will return `[RicerError::Unrecoverable]` if home directory cannot be
+    /// determined.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use anyhow::Result;
+    /// # fn main() -> Result<()> {
+    /// use ricer::config::{DirLayout, XdgDirLayout};
+    ///
+    /// let layout = XdgDirLayout::new_layout()?;
+    /// println!("{}", layout.config_dir().display());
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # See also
+    ///
+    /// - [`directories::BaseDir::new`][dirs]
+    /// - [XDG Base Directory Specification][xdg]
+    ///
+    /// [dirs]: https://docs.rs/directories/latest/directories/struct.BaseDirs.html#method.new
+    /// [xdg]: https://specifications.freedesktop.org/basedir-spec/latest/
+    /// [`RicerError::Unrecoverable`]: crate::error::RicerError::Unrecoverable
+    pub fn new_layout() -> Result<Self> {
+        trace!("Construct XDG Base Direcotry Specification layout handler");
+        let xdg_spec =
+            BaseDirs::new().ok_or(anyhow!("Failed to handle XDG Base Directoy Specification"))?;
+        Ok(Self { xdg_spec })
+    }
+}
+
+impl DirLayout for XdgDirLayout {
+    fn config_dir(&self) -> &Path {
+        self.xdg_spec.config_dir()
+    }
+
+    fn data_dir(&self) -> &Path {
+        self.xdg_spec.data_dir()
+    }
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -23,8 +23,8 @@
 //!
 //! [`RicerCli`]: crate::cli::RicerCli
 
-use std::fmt::{Display, Formatter, Result};
 use clap::ValueEnum;
+use std::fmt::{Display, Formatter, Result};
 
 mod clone;
 mod commit;

--- a/src/context.rs
+++ b/src/context.rs
@@ -24,32 +24,54 @@
 //! [`RicerCli`]: crate::cli::RicerCli
 
 use std::fmt::{Display, Formatter, Result};
+use clap::ValueEnum;
 
-pub mod clone;
-pub mod commit;
-pub mod delete;
-pub mod enter;
-pub mod init;
-pub mod list;
-pub mod pull;
-pub mod push;
-pub mod rename;
-pub mod repo_git;
-pub mod status;
+mod clone;
+mod commit;
+mod delete;
+mod enter;
+mod init;
+mod list;
+mod pull;
+mod push;
+mod rename;
+mod repo_git;
+mod status;
+
+#[doc(inline)]
+pub use clone::*;
+
+#[doc(inline)]
+pub use commit::*;
+
+#[doc(inline)]
+pub use delete::*;
+
+#[doc(inline)]
+pub use enter::*;
+
+#[doc(inline)]
+pub use init::*;
+
+#[doc(inline)]
+pub use list::*;
+
+#[doc(inline)]
+pub use pull::*;
+
+#[doc(inline)]
+pub use push::*;
+
+#[doc(inline)]
+pub use rename::*;
+
+#[doc(inline)]
+pub use repo_git::*;
+
+#[doc(inline)]
+pub use status::*;
 
 use crate::cli::{CommandSet, RicerCli, SharedOptions};
-use clap::ValueEnum;
-use clone::CloneContext;
-use commit::CommitContext;
-use delete::DeleteContext;
-use enter::EnterContext;
-use init::InitContext;
-use list::ListContext;
-use pull::PullContext;
-use push::PushContext;
-use rename::RenameContext;
-use repo_git::RepoGitContext;
-use status::StatusContext;
 
 /// Context states for each Ricer command.
 #[derive(Debug)]

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -60,10 +60,10 @@ where
     /// use std::ffi::OsString;
     ///
     /// use ricer::cli::RicerCli;
-    /// use ricer::config::dir::DefaultConfigDirManager;
-    /// use ricer::config::file::DefaultConfigFileManager;
-    /// use ricer::config::locator::{DefaultConfigDirLocator, DefaultXdgBaseDirSpec};
-    /// use ricer::config::ConfigManager;
+    /// use ricer::config::{
+    ///     ConfigManager, DefaultConfigDirManager, DefaultDirLocator, XdgDirLayout,
+    ///     DefaultConfigFileManager
+    /// };
     /// use ricer::context::Context;
     /// use ricer::hook::DefaultCommandHookManager;
     ///
@@ -331,10 +331,10 @@ where
     /// use std::ffi::OsString;
     ///
     /// use ricer::cli::RicerCli;
-    /// use ricer::config::dir::DefaultConfigDirManager;
-    /// use ricer::config::file::DefaultConfigFileManager;
-    /// use ricer::config::locator::{DefaultConfigDirLocator, DefaultXdgBaseDirSpec};
-    /// use ricer::config::ConfigManager;
+    /// use ricer::config::{
+    ///     ConfigManager, DefaultConfigDirManager, DefaultDirLocator, XdgDirLayout,
+    ///     DefaultConfigFileManager
+    /// };
     /// use ricer::context::Context;
     /// use ricer::hook::{CommandHookManager, DefaultCommandHookManager};
     ///
@@ -377,10 +377,10 @@ where
     /// use std::ffi::OsString;
     ///
     /// use ricer::cli::RicerCli;
-    /// use ricer::config::dir::DefaultConfigDirManager;
-    /// use ricer::config::file::DefaultConfigFileManager;
-    /// use ricer::config::locator::{DefaultConfigDirLocator, DefaultXdgBaseDirSpec};
-    /// use ricer::config::ConfigManager;
+    /// use ricer::config::{
+    ///     ConfigManager, DefaultConfigDirManager, DefaultDirLocator, XdgDirLayout,
+    ///     DefaultConfigFileManager
+    /// };
     /// use ricer::context::Context;
     /// use ricer::hook::{CommandHookManager, DefaultCommandHookManager};
     ///

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -18,10 +18,7 @@ use run_script::{run_script, ScriptOptions};
 use std::env;
 use std::path::PathBuf;
 
-use crate::config::dir::ConfigDirManager;
-use crate::config::file::hooks_section::HookEntry;
-use crate::config::file::ConfigFileManager;
-use crate::config::ConfigManager;
+use crate::config::{ConfigDirManager, HookEntry, ConfigFileManager, ConfigManager };
 use crate::context::{Context, HookAction};
 use crate::error::RicerResult;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,15 +44,12 @@
 use shadow_rs::shadow;
 shadow!(build);
 
-pub mod error;
-
 pub mod cli;
-
+pub mod config;
 pub mod context;
 
-pub mod config;
-
-pub mod hook;
+// pub mod error;
+// pub mod hook;
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
SPDX-License-Identifier: MIT
-->

## Description

Simplify the configuration directory locator API, and flatten the overall module structure to simplify API usage.

## Area of Effect

- Module `ricer::config`
- Module `ricer`
