### PR TITLE
Serialize and deserialize repository and command hook data in configuration files

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -589,6 +589,20 @@ impl RepoBootstrap {
     pub fn builder() -> RepoBootstrapBuilder {
         RepoBootstrapBuilder::new()
     }
+
+    /// Determine if repository has not bootstrap settings.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ricer::config::RepoBootstrap;
+    ///
+    /// let bootstrap = RepoBootstrap::default();
+    /// assert!(bootsrap.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.clone.is_none() && self.os.is_none() && self.users.is_none() && self.hosts.is_none()
+    }
 }
 
 /// Repository bootstrap configuration settigns.

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,7 @@ use anyhow::{anyhow, Result};
 use log::{debug, info, trace};
 use std::fmt;
 use std::str::FromStr;
+use toml_edit::visit::{visit_table_like_kv, Visit};
 use toml_edit::{DocumentMut, Item, Key, Table};
 
 /// TOML parser.
@@ -325,4 +326,72 @@ impl FromStr for Toml {
         let doc: DocumentMut = data.parse()?;
         Ok(Self { doc })
     }
+}
+
+/// Repository configuration settings.
+///
+/// Intermediary structure meant to help make it easier to deserialize and
+/// serialize repository configuration file data.
+#[derive(Debug, Default, Eq, PartialEq, Clone)]
+pub struct Repo {
+    /// Name of repository.
+    pub name: String,
+
+    /// Default branch.
+    pub branch: String,
+
+    /// Default remote.
+    pub remote: String,
+
+    /// Flag to determine if repository's working directory is the user's home
+    /// directory through _fake bare_ technique.
+    pub workdir_home: bool,
+
+    /// Bootstrap configuration for repository.
+    pub bootstrap: Option<RepoBootstrap>,
+}
+
+impl Repo {
+    // TODO: Implement this...
+}
+
+/// Repository bootstrap configuration settigns.
+#[derive(Debug, Default, Eq, PartialEq, Clone)]
+pub struct RepoBootstrap {
+    /// URL to clone repository from.
+    pub clone: Option<String>,
+
+    /// Bootstrap repository if and only if user is using a specific OS.
+    pub os: Option<OsType>,
+
+    /// Bootstrap repository if and only if user is logged on to a specific
+    /// set of user accounts.
+    pub users: Option<Vec<String>>,
+
+    /// Bootstrap repository if and only if user is logged on to a specific
+    /// set of hosts.
+    pub hosts: Option<Vec<String>>,
+}
+
+impl RepoBootstrap {
+    // TODO: Implement this...
+}
+
+/// Operating System settings.
+///
+/// Simple enum used to determine the target OS user wants to bootstrap with.
+#[derive(Debug, Default, Eq, PartialEq, Copy, Clone)]
+pub enum OsType {
+    /// Bootstrap to any operating system.
+    #[default]
+    Any,
+
+    /// Bootstrap to Unix-like systems only.
+    Unix,
+
+    /// Bootstrap to MacOS systems only.
+    MacOs,
+
+    /// Bootstrap to Windows system only.
+    Windows,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -358,7 +358,7 @@ impl Repo {
     /// # Examples
     ///
     /// ```no_run
-    /// let ricer::config::Repo;
+    /// use ricer::config::Repo;
     ///
     /// let builder = Repo::builder("vim");
     /// ```
@@ -371,7 +371,7 @@ impl Repo {
     /// # Examples
     ///
     /// ```no_run
-    /// use ricer::config::{RepoBuilder, RepoBootstrap};
+    /// use ricer::config::{Repo, RepoBootstrap};
     ///
     /// let bootstrap = RepoBootstrap::builder()
     ///     .clone("https://github.com/awkless/vim.git")
@@ -598,7 +598,7 @@ impl RepoBootstrap {
     /// use ricer::config::RepoBootstrap;
     ///
     /// let bootstrap = RepoBootstrap::default();
-    /// assert!(bootsrap.is_empty());
+    /// assert!(bootstrap.is_empty());
     /// ```
     pub fn is_empty(&self) -> bool {
         self.clone.is_none() && self.os.is_none() && self.users.is_none() && self.hosts.is_none()
@@ -633,9 +633,9 @@ impl RepoBootstrapBuilder {
     /// # Examples
     ///
     /// ```no_run
-    /// use ricer::config::RepoBootstrap;
+    /// use ricer::config::RepoBootstrapBuilder;
     ///
-    /// let builder = RepoBootstrap::new().clone("https://github.com/awkless/vim.git");
+    /// let builder = RepoBootstrapBuilder::new().clone("https://github.com/awkless/vim.git");
     /// ```
     pub fn clone(mut self, url: impl Into<String>) -> Self {
         self.clone = Some(url.into());
@@ -647,9 +647,9 @@ impl RepoBootstrapBuilder {
     /// # Examples
     ///
     /// ```no_run
-    /// use ricer::config::RepoBootstrap;
+    /// use ricer::config::{RepoBootstrapBuilder, OsType};
     ///
-    /// let builder = RepoBootstrap::new().os(OsType::Any);
+    /// let builder = RepoBootstrapBuilder::new().os(OsType::Any);
     /// ```
     pub fn os(mut self, os: OsType) -> Self {
         self.os = Some(os);
@@ -661,9 +661,9 @@ impl RepoBootstrapBuilder {
     /// # Examples
     ///
     /// ```no_run
-    /// use ricer::config::RepoBootstrap;
+    /// use ricer::config::RepoBootstrapBuilder;
     ///
-    /// let builder = RepoBootstrap::new().users(["awkless", "turing"]);
+    /// let builder = RepoBootstrapBuilder::new().users(["awkless", "turing"]);
     /// ```
     pub fn users<I, S>(mut self, users: I) -> Self
     where
@@ -681,9 +681,9 @@ impl RepoBootstrapBuilder {
     /// # Examples
     ///
     /// ```no_run
-    /// use ricer::config::RepoBootstrap;
+    /// use ricer::config::RepoBootstrapBuilder;
     ///
-    /// let builder = RepoBootstrap::new().hosts(["awkless", "turing"]);
+    /// let builder = RepoBootstrapBuilder::new().hosts(["awkless", "turing"]);
     /// ```
     pub fn hosts<I, S>(mut self, hosts: I) -> Self
     where

--- a/src/config.rs
+++ b/src/config.rs
@@ -705,6 +705,46 @@ impl RepoBootstrapBuilder {
     }
 }
 
+impl<'toml> Visit<'toml> for RepoBootstrapBuilder {
+    fn visit_table_like_kv(&mut self, key: &'toml str, node: &'toml Item) {
+        match key {
+            "clone" => {
+                if let Some(clone) = node.as_str() {
+                    self.clone = Some(clone.to_string())
+                }
+            }
+            "os" => {
+                if let Some(os) = node.as_str() {
+                    self.os = Some(OsType::from(os))
+                }
+            }
+            "users" => {
+                if let Some(users) = node.as_array() {
+                    let data = users
+                        .into_iter()
+                        .map(|s| {
+                            s.as_str().unwrap().trim_matches(|c| c == '\"' || c == '\'').to_string()
+                        })
+                        .collect();
+                    self.users = Some(data)
+                }
+            }
+            "hosts" => {
+                if let Some(hosts) = node.as_array() {
+                    let data = hosts
+                        .into_iter()
+                        .map(|s| {
+                            s.as_str().unwrap().trim_matches(|c| c == '\"' || c == '\'').to_string()
+                        })
+                        .collect();
+                    self.hosts = Some(data)
+                }
+            }
+            &_ => visit_table_like_kv(self, key, node),
+        }
+        visit_table_like_kv(self, key, node);
+    }
+}
 
 /// Operating System settings.
 ///

--- a/src/config.rs
+++ b/src/config.rs
@@ -818,5 +818,102 @@ pub struct Hook {
 }
 
 impl Hook {
-    // TODO: Implement this...
+    /// Build new hook definition.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer::config::Hook;
+    ///
+    /// let hook = Hook::builder()
+    ///     .pre("hook.sh")
+    ///     .pre("hook.sh")
+    ///     .workdir("/path/to/work/dir/")
+    ///     .build();
+    /// ```
+    pub fn builder() -> HookBuilder {
+        HookBuilder::new()
+    }
+}
+
+/// Builder for [`Hook`].
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct HookBuilder {
+    pre: Option<String>,
+    post: Option<String>,
+    workdir: Option<PathBuf>,
+}
+
+impl HookBuilder {
+    /// Construct new hook builder.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer::config::HookBuilder;
+    ///
+    /// let builder = HookBuilder::new();
+    /// ```
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Set hook to run _before_ command.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer::config::HookBuilder;
+    ///
+    /// let builder = HookBuilder::new().pre("hook.sh");
+    /// ```
+    pub fn pre(mut self, script: impl Into<String>) -> Self {
+        self.pre = Some(script.into());
+        self
+    }
+
+    /// Set hook to run _after_ command.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer::config::HookBuilder;
+    ///
+    /// let builder = HookBuilder::new().post("hook.sh");
+    /// ```
+    pub fn post(mut self, script: impl Into<String>) -> Self {
+        self.post = Some(script.into());
+        self
+    }
+
+    /// Set working directory of hook script.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer::config::HookBuilder;
+    ///
+    /// let builder = HookBuilder::new().workdir("/path/to/work/dir");
+    /// ```
+    pub fn workdir(mut self, path: impl Into<PathBuf>) -> Self {
+        self.workdir = Some(path.into());
+        self
+    }
+
+    /// Build new [`Hook`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer::config::HookBuilder;
+    ///
+    /// let hook = HookBuilder::new()
+    ///     .pre("hook.sh")
+    ///     .pre("hook.sh")
+    ///     .workdir("/path/to/work/dir/")
+    ///     .build();
+    /// ```
+    pub fn build(self) -> Hook {
+        Hook { pre: self.pre, post: self.post, workdir: self.workdir }
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,8 +32,8 @@ use log::{debug, info, trace};
 use std::fmt;
 use std::path::PathBuf;
 use std::str::FromStr;
-use toml_edit::visit::{visit_table_like_kv, visit_inline_table, Visit};
-use toml_edit::{Array, InlineTable, DocumentMut, Item, Key, Table, Value};
+use toml_edit::visit::{visit_inline_table, visit_table_like_kv, Visit};
+use toml_edit::{Array, DocumentMut, InlineTable, Item, Key, Table, Value};
 
 /// TOML parser.
 ///

--- a/src/config.rs
+++ b/src/config.rs
@@ -385,25 +385,25 @@ impl Repo {
     /// ```
     pub fn to_toml(&self) -> (Key, Item) {
         let mut repo = Table::new();
-        let mut bootstrap = Table::new();
+        let mut repo_bootstrap = Table::new();
 
         repo.insert("branch", Item::Value(Value::from(&self.branch)));
         repo.insert("remote", Item::Value(Value::from(&self.remote)));
         repo.insert("workdir_home", Item::Value(Value::from(self.workdir_home)));
         if let Some(bootstrap) = &self.bootstrap {
             if let Some(clone) = &bootstrap.clone {
-                bootstrap.insert("clone", Item::Value(Value::from(clone)));
+                repo_bootstrap.insert("clone", Item::Value(Value::from(clone)));
             }
             if let Some(os) = &bootstrap.os {
-                bootstrap.insert("os", Item::Value(Value::from(os.to_string())));
+                repo_bootstrap.insert("os", Item::Value(Value::from(os.to_string())));
             }
             if let Some(users) = &bootstrap.users {
-                bootstrap.insert("users", Item::Value(Value::Array(Array::from_iter(users))));
+                repo_bootstrap.insert("users", Item::Value(Value::Array(Array::from_iter(users))));
             }
-            if let Some(hosts) &bootstrap.hosts {
-                bootstrap.insert("hosts", Item::Value(Value::Array(Array::from_iter(hosts))));
+            if let Some(hosts) = &bootstrap.hosts {
+                repo_bootstrap.insert("hosts", Item::Value(Value::Array(Array::from_iter(hosts))));
             }
-            repo.insert("bootstrap", Item::Table(bootstrap));
+            repo.insert("bootstrap", Item::Table(repo_bootstrap));
         }
 
         let key = Key::new(&self.name);

--- a/src/config.rs
+++ b/src/config.rs
@@ -576,8 +576,135 @@ pub struct RepoBootstrap {
 }
 
 impl RepoBootstrap {
-    // TODO: Implement this...
+    /// Build new bootstrap settings for repository.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer::config::RepoBootstrap;
+    ///
+    /// let builder = RepoBootstrap::builder();
+    /// ```
+    pub fn builder() -> RepoBootstrapBuilder {
+        RepoBootstrapBuilder::new()
+    }
 }
+
+/// Repository bootstrap configuration settigns.
+#[derive(Debug, Default, Eq, PartialEq, Clone)]
+pub struct RepoBootstrapBuilder {
+    clone: Option<String>,
+    os: Option<OsType>,
+    users: Option<Vec<String>>,
+    hosts: Option<Vec<String>>,
+}
+
+impl RepoBootstrapBuilder {
+    /// Construct new repository bootstrap settings builder.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer::config::RepoBootstrapBuilder;
+    ///
+    /// let builder = RepoBootstrapBuilder::new();
+    /// ```
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Set URL to clone repository from.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer::config::RepoBootstrap;
+    ///
+    /// let builder = RepoBootstrap::new().clone("https://github.com/awkless/vim.git");
+    /// ```
+    pub fn clone(mut self, url: impl Into<String>) -> Self {
+        self.clone = Some(url.into());
+        self
+    }
+
+    /// Set target operating system to bootstrap repository too.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer::config::RepoBootstrap;
+    ///
+    /// let builder = RepoBootstrap::new().os(OsType::Any);
+    /// ```
+    pub fn os(mut self, os: OsType) -> Self {
+        self.os = Some(os);
+        self
+    }
+
+    /// Set target users to bootsrap repository too.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer::config::RepoBootstrap;
+    ///
+    /// let builder = RepoBootstrap::new().users(["awkless", "turing"]);
+    /// ```
+    pub fn users<I, S>(mut self, users: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let mut vec = Vec::new();
+        vec.extend(users.into_iter().map(Into::into));
+        self.users = Some(vec);
+        self
+    }
+
+    /// Set target hosts to bootstrap repository too.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer::config::RepoBootstrap;
+    ///
+    /// let builder = RepoBootstrap::new().hosts(["awkless", "turing"]);
+    /// ```
+    pub fn hosts<I, S>(mut self, hosts: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let mut vec = Vec::new();
+        vec.extend(hosts.into_iter().map(Into::into));
+        self.hosts = Some(vec);
+        self
+    }
+
+    /// Build [`RepoBootstrap`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer::config::{RepoBootstrapBuilder, OsType};
+    ///
+    /// let bootstrap = RepoBootstrapBuilder::new()
+    ///     .clone("https://github.com/awkless/vim.git")
+    ///     .os(OsType::Unix)
+    ///     .users(["awkless", "knuth", "goodwill"])
+    ///     .hosts(["lovelace", "dijkstra", "turing"])
+    ///     .build();
+    /// ```
+    pub fn build(self) -> RepoBootstrap {
+        RepoBootstrap {
+            clone: self.clone,
+            os: self.os,
+            users: self.users,
+            hosts: self.hosts,
+        }
+    }
+}
+
 
 /// Operating System settings.
 ///

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,7 +32,7 @@ use log::{debug, info, trace};
 use std::fmt;
 use std::str::FromStr;
 use toml_edit::visit::{visit_table_like_kv, Visit};
-use toml_edit::{DocumentMut, Item, Key, Table};
+use toml_edit::{DocumentMut, Item, Key, Table, Value, Array};
 
 /// TOML parser.
 ///
@@ -352,7 +352,80 @@ pub struct Repo {
 }
 
 impl Repo {
-    // TODO: Implement this...
+    /// Build new repository settings.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// let ricer::config::Repo;
+    ///
+    /// let builder = Repo::builder("vim");
+    /// ```
+    pub fn builder(name: impl AsRef<str>) -> RepoBuilder {
+        RepoBuilder::new(name.as_ref())
+    }
+
+    /// Serialize repository settings to TOML document entry.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer::config::{RepoBuilder, RepoBootstrap};
+    ///
+    /// let bootstrap = RepoBootstrap::builder()
+    ///     .clone("https://github.com/awkless/vim.git")
+    ///     .build();
+    /// let repo = Repo::builder("vim")
+    ///     .branch("master")
+    ///     .remote("origin")
+    ///     .workdir_home(true)
+    ///     .bootstrap(bootstrap)
+    ///     .build();
+    /// let entry = repo.to_toml();
+    /// ```
+    pub fn to_toml(&self) -> (Key, Item) {
+        let mut repo = Table::new();
+        let mut bootstrap = Table::new();
+
+        repo.insert("branch", Item::Value(Value::from(&self.branch)));
+        repo.insert("remote", Item::Value(Value::from(&self.remote)));
+        repo.insert("workdir_home", Item::Value(Value::from(self.workdir_home)));
+        if let Some(bootstrap) = &self.bootstrap {
+            if let Some(clone) = &bootstrap.clone {
+                bootstrap.insert("clone", Item::Value(Value::from(clone)));
+            }
+            if let Some(os) = &bootstrap.os {
+                bootstrap.insert("os", Item::Value(Value::from(os.to_string())));
+            }
+            if let Some(users) = &bootstrap.users {
+                bootstrap.insert("users", Item::Value(Value::Array(Array::from_iter(users))));
+            }
+            if let Some(hosts) &bootstrap.hosts {
+                bootstrap.insert("hosts", Item::Value(Value::Array(Array::from_iter(hosts))));
+            }
+            repo.insert("bootstrap", Item::Table(bootstrap));
+        }
+
+        let key = Key::new(&self.name);
+        let value = Item::Table(repo);
+        (key, value)
+    }
+}
+
+impl<'toml> From<(&'toml Key, &'toml Item)> for Repo {
+    fn from(entry: (&'toml Key, &'toml Item)) -> Self {
+        let (key, value) = entry;
+        let mut bootstrap = RepoBootstrap::builder();
+        let mut repo = Repo::builder(key.get());
+        bootstrap.visit_item(value);
+        repo.visit_item(value);
+
+        let bootstrap = bootstrap.build();
+        if !bootstrap.is_empty() {
+            repo = repo.bootstrap(bootstrap);
+        }
+        repo.build()
+    }
 }
 
 /// Builder for [`Repo`].
@@ -413,16 +486,54 @@ impl RepoBuilder {
         self
     }
 
+    /// Set repository to use user's home as the main working directory.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer::config::RepoBuilder;
+    ///
+    /// let builder = RepoBuilder::new("vim").workdir_home(true);
+    /// ```
     pub fn workdir_home(mut self, choice: bool) -> Self {
         self.workdir_home = choice;
         self
     }
 
+    /// Set bootstrapping options for repository.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer::config::{RepoBuilder, RepoBootstrap};
+    ///
+    /// let bootstrap = RepoBootstrap::builder()
+    ///     .clone("https://github.com/awkless/vim.git")
+    ///     .build();
+    /// let builder = RepoBuilder::new("vim").bootstrap(bootstrap);
+    /// ```
     pub fn bootstrap(mut self, bootstrap: RepoBootstrap) -> Self {
         self.bootstrap = Some(bootstrap);
         self
     }
 
+    /// Build new [`Repo`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer::config::{RepoBuilder, RepoBootstrap};
+    ///
+    /// let bootstrap = RepoBootstrap::builder()
+    ///     .clone("https://github.com/awkless/vim.git")
+    ///     .build();
+    /// let repo = RepoBuilder::new("vim")
+    ///     .branch("master")
+    ///     .remote("origin")
+    ///     .workdir_home(true)
+    ///     .bootstrap(bootstrap)
+    ///     .build();
+    /// ```
     pub fn build(self) -> Repo {
         Repo {
             name: self.name,
@@ -431,6 +542,18 @@ impl RepoBuilder {
             workdir_home: self.workdir_home,
             bootstrap: self.bootstrap,
         }
+    }
+}
+
+impl<'toml> Visit<'toml> for RepoBuilder {
+    fn visit_table_like_kv(&mut self, key: &'toml str, node: &'toml Item) {
+        match key {
+            "branch" => self.branch = node.as_str().unwrap_or_default().to_string(),
+            "remote" => self.remote = node.as_str().unwrap_or_default().to_string(),
+            "workdir_home" => self.workdir_home = node.as_bool().unwrap_or_default(),
+            &_ => visit_table_like_kv(self, key, node),
+        }
+        visit_table_like_kv(self, key, node);
     }
 }
 
@@ -473,4 +596,27 @@ pub enum OsType {
 
     /// Bootstrap to Windows system only.
     Windows,
+}
+
+impl From<&str> for OsType {
+    fn from(data: &str) -> Self {
+        match data {
+            "any" => Self::Any,
+            "unix" => Self::Unix,
+            "macos" => Self::MacOs,
+            "windows" => Self::Windows,
+            &_ => Self::Any,
+        }
+    }
+}
+
+impl fmt::Display for OsType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OsType::Any => write!(f, "any"),
+            OsType::Unix => write!(f, "unix"),
+            OsType::MacOs => write!(f, "macos"),
+            OsType::Windows => write!(f, "windows"),
+        }
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,8 +32,8 @@ use log::{debug, info, trace};
 use std::fmt;
 use std::path::PathBuf;
 use std::str::FromStr;
-use toml_edit::visit::{visit_table_like_kv, Visit};
-use toml_edit::{Array, DocumentMut, Item, Key, Table, Value};
+use toml_edit::visit::{visit_table_like_kv, visit_inline_table, Visit};
+use toml_edit::{Array, InlineTable, DocumentMut, Item, Key, Table, Value};
 
 /// TOML parser.
 ///
@@ -812,7 +812,62 @@ pub struct CmdHook {
 }
 
 impl CmdHook {
-    // TODO: Implement this...
+    /// Construct new command hook definition.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer::config::CmdHook;
+    ///
+    /// let cmd_hook = CmdHook::new("commit");
+    /// ```
+    pub fn new(cmd: impl Into<String>) -> Self {
+        Self { cmd: cmd.into(), hooks: Default::default() }
+    }
+
+    /// Add hook definition into command hook list.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer::config::{CmdHook, Hook};
+    ///
+    /// let mut cmd_hook = CmdHook::new("commit");
+    /// let hook = Hook::builder()
+    ///     .pre("hook.sh")
+    ///     .post("hook.sh")
+    ///     .workdir("/path/to/work/dir")
+    ///     .build();
+    /// cmd_hook.add_hook(hook);
+    /// ```
+    pub fn add_hook(&mut self, hook: Hook) {
+        self.hooks.push(hook);
+    }
+}
+
+impl<'toml> From<(&'toml Key, &'toml Item)> for CmdHook {
+    fn from(entry: (&'toml Key, &'toml Item)) -> Self {
+        let (key, value) = entry;
+        let mut cmd_hook = CmdHook::new(key.get());
+        cmd_hook.visit_item(value);
+        cmd_hook
+    }
+}
+
+impl<'toml> Visit<'toml> for CmdHook {
+    fn visit_inline_table(&mut self, node: &'toml InlineTable) {
+        let pre = if let Some(pre) = node.get("pre") { pre.as_str() } else { None };
+        let post = if let Some(post) = node.get("post") { post.as_str() } else { None };
+        let workdir = if let Some(workdir) = node.get("workdir") { workdir.as_str() } else { None };
+
+        let hook = Hook::builder();
+        let hook = if let Some(pre) = pre { hook.pre(pre) } else { hook };
+        let hook = if let Some(post) = post { hook.post(post) } else { hook };
+        let hook = if let Some(workdir) = workdir { hook.workdir(workdir) } else { hook };
+        self.add_hook(hook.build());
+
+        visit_inline_table(self, node);
+    }
 }
 
 /// Hook definition settings.

--- a/src/config.rs
+++ b/src/config.rs
@@ -869,7 +869,7 @@ impl CmdHook {
             decor.set_prefix("\n    ");
 
             if iter.peek().is_none() {
-                decor.set_prefix("\n");
+                decor.set_suffix("\n");
             }
 
             if let Some(pre) = &hook.pre {

--- a/src/config.rs
+++ b/src/config.rs
@@ -843,6 +843,54 @@ impl CmdHook {
     pub fn add_hook(&mut self, hook: Hook) {
         self.hooks.push(hook);
     }
+
+    /// Serialize command hook into TOML document entry.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer::config::{CmdHook, Hook};
+    ///
+    /// let mut cmd_hook = CmdHook::new("commit");
+    /// let hook = Hook::builder()
+    ///     .pre("hook.sh")
+    ///     .post("hook.sh")
+    ///     .workdir("/path/to/work/dir")
+    ///     .build();
+    /// cmd_hook.add_hook(hook);
+    /// let entry = cmd_hook.to_toml();
+    /// ```
+    pub fn to_toml(&self) -> (Key, Item) {
+        let mut tables = Array::new();
+        let mut iter = self.hooks.iter().enumerate().peekable();
+        while let Some((_, hook)) = iter.next() {
+            let mut inline = InlineTable::new();
+            let decor = inline.decor_mut();
+            decor.set_prefix("\n    ");
+
+            if iter.peek().is_none() {
+                decor.set_prefix("\n");
+            }
+
+            if let Some(pre) = &hook.pre {
+                inline.insert("pre", Value::from(pre));
+            }
+
+            if let Some(post) = &hook.post {
+                inline.insert("post", Value::from(post));
+            }
+
+            if let Some(workdir) = &hook.workdir {
+                inline.insert("workdir", Value::from(String::from(workdir.to_string_lossy())));
+            }
+
+            tables.push_formatted(Value::from(inline));
+        }
+
+        let key = Key::new(&self.cmd);
+        let value = Item::Value(Value::from(tables));
+        (key, value)
+    }
 }
 
 impl<'toml> From<(&'toml Key, &'toml Item)> for CmdHook {

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,9 +30,10 @@
 use anyhow::{anyhow, Result};
 use log::{debug, info, trace};
 use std::fmt;
+use std::path::PathBuf;
 use std::str::FromStr;
 use toml_edit::visit::{visit_table_like_kv, Visit};
-use toml_edit::{DocumentMut, Item, Key, Table, Value, Array};
+use toml_edit::{Array, DocumentMut, Item, Key, Table, Value};
 
 /// TOML parser.
 ///
@@ -696,12 +697,7 @@ impl RepoBootstrapBuilder {
     ///     .build();
     /// ```
     pub fn build(self) -> RepoBootstrap {
-        RepoBootstrap {
-            clone: self.clone,
-            os: self.os,
-            users: self.users,
-            hosts: self.hosts,
-        }
+        RepoBootstrap { clone: self.clone, os: self.os, users: self.users, hosts: self.hosts }
     }
 }
 
@@ -786,4 +782,41 @@ impl fmt::Display for OsType {
             OsType::Windows => write!(f, "windows"),
         }
     }
+}
+
+/// Command hook settings.
+///
+/// An intermediary structure to help deserialize and serialize command hook
+/// from Ricer's command hook configuration file.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct CmdHook {
+    /// Name of command to bind hook definitions too.
+    pub cmd: String,
+
+    /// Array of hook definitions to execute.
+    pub hooks: Vec<Hook>,
+}
+
+impl CmdHook {
+    // TODO: Implement this...
+}
+
+/// Hook definition settings.
+///
+/// An intermediary structure to help deserialize and serialize hook entries
+/// for command hook settings in command hook configuration file.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct Hook {
+    /// Execute hook script _before_ command itself.
+    pub pre: Option<String>,
+
+    /// Execute hook script _after_ command itself.
+    pub post: Option<String>,
+
+    /// Set working directory of hook script.
+    pub workdir: Option<PathBuf>,
+}
+
+impl Hook {
+    // TODO: Implement this...
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -355,6 +355,85 @@ impl Repo {
     // TODO: Implement this...
 }
 
+/// Builder for [`Repo`].
+#[derive(Debug, Default, Eq, PartialEq, Clone)]
+pub struct RepoBuilder {
+    name: String,
+    branch: String,
+    remote: String,
+    workdir_home: bool,
+    bootstrap: Option<RepoBootstrap>,
+}
+
+impl RepoBuilder {
+    /// Construct new repository setting builder.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer::config::RepoBuilder;
+    ///
+    /// let builder = RepoBuilder::new("vim");
+    /// ```
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            branch: Default::default(),
+            remote: Default::default(),
+            workdir_home: Default::default(),
+            bootstrap: Default::default(),
+        }
+    }
+
+    /// Set default branch to use in repository.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer::config::RepoBuilder;
+    ///
+    /// let builder = RepoBuilder::new("vim").branch("master");
+    /// ```
+    pub fn branch(mut self, branch: impl Into<String>) -> Self {
+        self.branch = branch.into();
+        self
+    }
+
+    /// Set default remote to use in repository.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ricer::config::RepoBuilder;
+    ///
+    /// let builder = RepoBuilder::new("vim").remote("origin");
+    /// ```
+    pub fn remote(mut self, remote: impl Into<String>) -> Self {
+        self.remote = remote.into();
+        self
+    }
+
+    pub fn workdir_home(mut self, choice: bool) -> Self {
+        self.workdir_home = choice;
+        self
+    }
+
+    pub fn bootstrap(mut self, bootstrap: RepoBootstrap) -> Self {
+        self.bootstrap = Some(bootstrap);
+        self
+    }
+
+    pub fn build(self) -> Repo {
+        Repo {
+            name: self.name,
+            branch: self.branch,
+            remote: self.remote,
+            workdir_home: self.workdir_home,
+            bootstrap: self.bootstrap,
+        }
+    }
+}
+
 /// Repository bootstrap configuration settigns.
 #[derive(Debug, Default, Eq, PartialEq, Clone)]
 pub struct RepoBootstrap {

--- a/src/tests/config.rs
+++ b/src/tests/config.rs
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: MIT
 
-mod toml;
-mod repo;
 mod cmd_hook;
+mod repo;
+mod toml;

--- a/src/tests/config.rs
+++ b/src/tests/config.rs
@@ -2,3 +2,4 @@
 // SPDX-License-Identifier: MIT
 
 mod toml;
+mod repo;

--- a/src/tests/config.rs
+++ b/src/tests/config.rs
@@ -3,3 +3,4 @@
 
 mod toml;
 mod repo;
+mod cmd_hook;

--- a/src/tests/config/cmd_hook.rs
+++ b/src/tests/config/cmd_hook.rs
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: MIT
+
+use anyhow::Result;
+use indoc::indoc;
+use pretty_assertions::assert_eq;
+use toml_edit::{DocumentMut, Item, Key};
+
+use crate::config::{CmdHook, Hook};
+
+fn setup_toml_doc(entry: (Key, Item)) -> Result<DocumentMut> {
+    let mut doc: DocumentMut = "[hooks]".parse()?;
+    let table = doc.get_mut("hooks").unwrap();
+    let table = table.as_table_mut().unwrap();
+    let (key, item) = entry;
+    table.insert_formatted(&key, item);
+    table.set_implicit(true);
+    Ok(doc)
+}
+
+#[test]
+fn to_toml_serializes_correctly() -> Result<()> {
+    let mut cmd_hook = CmdHook::new("commit");
+    cmd_hook.add_hook(
+        Hook::builder().pre("hook.sh").post("hook.sh").workdir("/some/path").build(),
+    );
+    cmd_hook.add_hook(Hook::builder().pre("hook.sh").build());
+    cmd_hook.add_hook(Hook::builder().post("hook.sh").build());
+    let entry = cmd_hook.to_toml();
+    let doc = setup_toml_doc(entry)?;
+    let expect = indoc! {r#"
+        [hooks]
+        commit = [
+            { pre = "hook.sh", post = "hook.sh", workdir = "/some/path" },
+            { pre = "hook.sh" },
+            { post = "hook.sh" }
+        ]
+    "#};
+    let result = doc.to_string();
+    assert_eq!(expect, result);
+    Ok(())
+}
+
+#[test]
+fn from_deserializes_correctly() -> Result<()> {
+    let mut expect = CmdHook::new("commit");
+    expect.add_hook(
+        Hook::builder().pre("hook.sh").post("hook.sh").workdir("/some/path").build(),
+    );
+    expect.add_hook(Hook::builder().pre("hook.sh").build());
+    expect.add_hook(Hook::builder().post("hook.sh").build());
+    let entry = expect.to_toml();
+    let doc = setup_toml_doc(entry)?;
+    let result = CmdHook::from(
+        doc.get("hooks").unwrap().as_table().unwrap().get_key_value("commit").unwrap(),
+    );
+    assert_eq!(expect, result);
+    Ok(())
+}

--- a/src/tests/config/cmd_hook.rs
+++ b/src/tests/config/cmd_hook.rs
@@ -21,9 +21,7 @@ fn setup_toml_doc(entry: (Key, Item)) -> Result<DocumentMut> {
 #[test]
 fn to_toml_serializes_correctly() -> Result<()> {
     let mut cmd_hook = CmdHook::new("commit");
-    cmd_hook.add_hook(
-        Hook::builder().pre("hook.sh").post("hook.sh").workdir("/some/path").build(),
-    );
+    cmd_hook.add_hook(Hook::builder().pre("hook.sh").post("hook.sh").workdir("/some/path").build());
     cmd_hook.add_hook(Hook::builder().pre("hook.sh").build());
     cmd_hook.add_hook(Hook::builder().post("hook.sh").build());
     let entry = cmd_hook.to_toml();
@@ -44,9 +42,7 @@ fn to_toml_serializes_correctly() -> Result<()> {
 #[test]
 fn from_deserializes_correctly() -> Result<()> {
     let mut expect = CmdHook::new("commit");
-    expect.add_hook(
-        Hook::builder().pre("hook.sh").post("hook.sh").workdir("/some/path").build(),
-    );
+    expect.add_hook(Hook::builder().pre("hook.sh").post("hook.sh").workdir("/some/path").build());
     expect.add_hook(Hook::builder().pre("hook.sh").build());
     expect.add_hook(Hook::builder().post("hook.sh").build());
     let entry = expect.to_toml();

--- a/src/tests/config/repo.rs
+++ b/src/tests/config/repo.rs
@@ -6,7 +6,7 @@ use indoc::indoc;
 use pretty_assertions::assert_eq;
 use toml_edit::{DocumentMut, Item, Key};
 
-use crate::config::{OsType, RepoBootstrap, Repo};
+use crate::config::{OsType, Repo, RepoBootstrap};
 
 fn setup_toml_doc(entry: (Key, Item)) -> Result<DocumentMut> {
     let mut doc: DocumentMut = "[repos]".parse()?;
@@ -53,8 +53,7 @@ fn to_toml_serializes_correctly() -> Result<()> {
 
 #[test]
 fn to_toml_serializes_without_bootstrap_entry() -> Result<()> {
-    let repo =
-        Repo::builder("vim").branch("master").remote("origin").workdir_home(true).build();
+    let repo = Repo::builder("vim").branch("master").remote("origin").workdir_home(true).build();
     let entry = repo.to_toml();
     let doc = setup_toml_doc(entry)?;
     let expect = indoc! {r#"
@@ -84,22 +83,19 @@ fn from_deserializes_correctly() -> Result<()> {
         .build();
     let entry = expect.to_toml();
     let doc = setup_toml_doc(entry)?;
-    let result = Repo::from(
-        doc.get("repos").unwrap().as_table().unwrap().get_key_value("vim").unwrap(),
-    );
+    let result =
+        Repo::from(doc.get("repos").unwrap().as_table().unwrap().get_key_value("vim").unwrap());
     assert_eq!(expect, result);
     Ok(())
 }
 
 #[test]
 fn from_deserializes_without_bootstrap_entry() -> Result<()> {
-    let expect =
-        Repo::builder("vim").branch("master").remote("origin").workdir_home(true).build();
+    let expect = Repo::builder("vim").branch("master").remote("origin").workdir_home(true).build();
     let entry = expect.to_toml();
     let doc = setup_toml_doc(entry)?;
-    let result = Repo::from(
-        doc.get("repos").unwrap().as_table().unwrap().get_key_value("vim").unwrap(),
-    );
+    let result =
+        Repo::from(doc.get("repos").unwrap().as_table().unwrap().get_key_value("vim").unwrap());
     assert_eq!(expect, result);
     Ok(())
 }

--- a/src/tests/config/repo.rs
+++ b/src/tests/config/repo.rs
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: MIT
+
+use anyhow::Result;
+use indoc::indoc;
+use pretty_assertions::assert_eq;
+use toml_edit::{DocumentMut, Item, Key};
+
+use crate::config::{OsType, RepoBootstrap, Repo};
+
+fn setup_toml_doc(entry: (Key, Item)) -> Result<DocumentMut> {
+    let mut doc: DocumentMut = "[repos]".parse()?;
+    let table = doc.get_mut("repos").unwrap();
+    let table = table.as_table_mut().unwrap();
+    let (key, item) = entry;
+    table.insert_formatted(&key, item);
+    table.set_implicit(true);
+    Ok(doc)
+}
+
+#[test]
+fn to_toml_serializes_correctly() -> Result<()> {
+    let bootstrap = RepoBootstrap::builder()
+        .clone("https://github.com/awkless/vim.git")
+        .os(OsType::Unix)
+        .users(["awkless", "sedgwick"])
+        .hosts(["lovelace", "turing"])
+        .build();
+    let repo = Repo::builder("vim")
+        .branch("master")
+        .remote("origin")
+        .workdir_home(true)
+        .bootstrap(bootstrap)
+        .build();
+    let entry = repo.to_toml();
+    let doc = setup_toml_doc(entry)?;
+    let expect = indoc! {r#"
+        [repos.vim]
+        branch = "master"
+        remote = "origin"
+        workdir_home = true
+
+        [repos.vim.bootstrap]
+        clone = "https://github.com/awkless/vim.git"
+        os = "unix"
+        users = ["awkless", "sedgwick"]
+        hosts = ["lovelace", "turing"]
+    "#};
+    let result = doc.to_string();
+    assert_eq!(expect, result);
+    Ok(())
+}
+
+#[test]
+fn to_toml_serializes_without_bootstrap_entry() -> Result<()> {
+    let repo =
+        Repo::builder("vim").branch("master").remote("origin").workdir_home(true).build();
+    let entry = repo.to_toml();
+    let doc = setup_toml_doc(entry)?;
+    let expect = indoc! {r#"
+        [repos.vim]
+        branch = "master"
+        remote = "origin"
+        workdir_home = true
+    "#};
+    let result = doc.to_string();
+    assert_eq!(expect, result);
+    Ok(())
+}
+
+#[test]
+fn from_deserializes_correctly() -> Result<()> {
+    let bootstrap = RepoBootstrap::builder()
+        .clone("https://github.com/awkless/vim.git")
+        .os(OsType::Unix)
+        .users(["awkless", "sedgwick"])
+        .hosts(["lovelace", "turing"])
+        .build();
+    let expect = Repo::builder("vim")
+        .branch("master")
+        .remote("origin")
+        .workdir_home(true)
+        .bootstrap(bootstrap)
+        .build();
+    let entry = expect.to_toml();
+    let doc = setup_toml_doc(entry)?;
+    let result = Repo::from(
+        doc.get("repos").unwrap().as_table().unwrap().get_key_value("vim").unwrap(),
+    );
+    assert_eq!(expect, result);
+    Ok(())
+}
+
+#[test]
+fn from_deserializes_without_bootstrap_entry() -> Result<()> {
+    let expect =
+        Repo::builder("vim").branch("master").remote("origin").workdir_home(true).build();
+    let entry = expect.to_toml();
+    let doc = setup_toml_doc(entry)?;
+    let result = Repo::from(
+        doc.get("repos").unwrap().as_table().unwrap().get_key_value("vim").unwrap(),
+    );
+    assert_eq!(expect, result);
+    Ok(())
+}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
SPDX-License-Identifier: MIT
-->

## Description

Made many changes to the configuration file layout for repository and command hook data. These changes are now reflected and handled by this pull request for serialization and deserialization.

## Area of Effect

- Module `ricer::config`.
