### PR TITLE
Implement TOML parser

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@
 
 use log::trace;
 use toml_edit::DocumentMut;
+use std::fmt;
 
 #[derive(Clone, Default, Debug)]
 pub struct Toml {
@@ -13,5 +14,11 @@ impl Toml {
     pub fn new() -> Self {
         trace!("Construct new TOML parser");
         Self { doc: DocumentMut::new() }
+    }
+}
+
+impl fmt::Display for Toml {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.doc)
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: MIT
 
-use crate::error::RicerError;
+use crate::error::{RicerError, RicerResult};
 
 use anyhow::anyhow;
 use log::trace;
 use std::fmt;
 use std::str::FromStr;
-use toml_edit::DocumentMut;
+use toml_edit::{DocumentMut, Key, Item};
 
 #[derive(Clone, Default, Debug)]
 pub struct Toml {
@@ -18,6 +18,31 @@ impl Toml {
     pub fn new() -> Self {
         trace!("Construct new TOML parser");
         Self { doc: DocumentMut::new() }
+    }
+
+    pub fn add(&mut self, table: impl AsRef<str>, entry: (Key, Item)) -> RicerResult<Option<(Key, Item)>> {
+        todo!();
+    }
+
+    pub fn get<S>(&self, table: S, key: S) -> RicerResult<(&Key, &Item)>
+    where
+        S: AsRef<str>,
+    {
+        todo!();
+    }
+
+    pub fn rename<S>(&mut self, table: S, from: S, to: S) -> RicerResult<(Key, Item)>
+    where
+        S: AsRef<str>,
+    {
+        todo!();
+    }
+
+    pub fn remove<S>(&mut self, table: S, key: S) -> RicerResult<(Key, Item)>
+    where
+        S: AsRef<str>,
+    {
+        todo!();
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: MIT
 
+use log::trace;
 use toml_edit::DocumentMut;
 
 #[derive(Clone, Default, Debug)]
@@ -9,5 +10,8 @@ pub struct Toml {
 }
 
 impl Toml {
-    // TODO: implement this...
+    pub fn new() -> Self {
+        trace!("Construct new TOML parser");
+        Self { doc: DocumentMut::new() }
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,9 +1,13 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: MIT
 
+use crate::error::RicerError;
+
+use anyhow::anyhow;
 use log::trace;
-use toml_edit::DocumentMut;
 use std::fmt;
+use std::str::FromStr;
+use toml_edit::DocumentMut;
 
 #[derive(Clone, Default, Debug)]
 pub struct Toml {
@@ -20,5 +24,15 @@ impl Toml {
 impl fmt::Display for Toml {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.doc)
+    }
+}
+
+impl FromStr for Toml {
+    type Err = RicerError;
+
+    fn from_str(data: &str) -> Result<Self, Self::Err> {
+        let doc: DocumentMut =
+            data.parse().map_err(|e| -> RicerError { anyhow!("{}", e).into() })?;
+        Ok(Self { doc })
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -94,11 +94,32 @@ impl Toml {
         todo!();
     }
 
+    /// Remove TOML entry from document.
+    ///
+    /// Remove `key` from target `table`. Returns removed entry.
+    ///
+    /// # Errors
+    ///
+    /// - Return [`TomlError::TableNotFound`] if target table is not found
+    ///   in document.
+    /// - Return [`TomlError::NotTable`] if target table was not defined as
+    ///   a table.
+    /// - Return [`TomlError::EntryNotFound`] if target key-value pair
+    ///   is not found in document.
+    ///
+    /// [`TomlError::TableNotFound`]: crate::config::TomlError::TableNotFound
+    /// [`TomlError::NotTable`]: crate::config::TomlError::NotTable
+    /// [`TomlError::EntryNotFound`]: crate::config::TomlError::EntryNotFound
     pub fn remove<S>(&mut self, table: S, key: S) -> Result<(Key, Item), TomlError>
     where
         S: AsRef<str>,
     {
-        todo!();
+        let entry = self.get_table_mut(table.as_ref())?;
+        let entry = entry.remove_entry(key.as_ref()).ok_or_else(|| TomlError::EntryNotFound {
+            table: table.as_ref().into(),
+            key: key.as_ref().into()
+        })?;
+        Ok(entry)
     }
 
     /// Get target table in document.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: MIT
+
+use toml_edit::DocumentMut;
+
+#[derive(Clone, Default, Debug)]
+pub struct Toml {
+    doc: DocumentMut,
+}
+
+impl Toml {
+    // TODO: implement this...
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,10 +4,10 @@
 use crate::error::{RicerError, RicerResult};
 
 use anyhow::anyhow;
-use log::trace;
+use log::{trace, info, debug};
 use std::fmt;
 use std::str::FromStr;
-use toml_edit::{DocumentMut, Key, Item};
+use toml_edit::{DocumentMut, Item, Key, Table};
 
 #[derive(Clone, Default, Debug)]
 pub struct Toml {
@@ -20,7 +20,11 @@ impl Toml {
         Self { doc: DocumentMut::new() }
     }
 
-    pub fn add(&mut self, table: impl AsRef<str>, entry: (Key, Item)) -> RicerResult<Option<(Key, Item)>> {
+    pub fn add(
+        &mut self,
+        table: impl AsRef<str>,
+        entry: (Key, Item),
+    ) -> RicerResult<Option<(Key, Item)>> {
         todo!();
     }
 
@@ -43,6 +47,19 @@ impl Toml {
         S: AsRef<str>,
     {
         todo!();
+    }
+
+    pub(crate) fn get_table(&self, key: &str) -> RicerResult<&Table> {
+        debug!("Get TOML table '{key}'");
+        let table = self
+            .doc
+            .get(key)
+            .ok_or_else(|| anyhow!("TOML entry '{key}' does not exist"))
+            .map_err(RicerError::TomlEntryNotFound)?;
+        let table = table.as_table()
+            .ok_or_else(|| anyhow!("TOML entry '{key}' is not a table"))
+            .map_err(RicerError::TomlEntryNonTable)?;
+        Ok(table)
     }
 }
 

--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: MIT
+
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+pub enum TomlError {
+    #[error("Failed to parse TOML data")]
+    BadParse { source: toml_edit::TomlError },
+
+    #[error("TOML table '{table}' not found")]
+    TableNotFound { table: String },
+
+    #[error("TOML table '{table}' not defined as a table")]
+    NotTable { table: String },
+
+    #[error("TOML entry '{key}' not found in table '{table}'")]
+    EntryNotFound { table: String, key: String },
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@
 //! [contrib-guide]: https://github.com/rice-configs/ricer/blob/main/CONTRIBUTING.md
 
 pub mod cli;
+pub mod config;
 pub mod context;
 
 #[cfg(test)]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: MIT
 
+mod config;
 mod context;
 mod ui;

--- a/src/tests/config.rs
+++ b/src/tests/config.rs
@@ -139,14 +139,6 @@ fn toml_add_catches_errors(#[case] input: &str, #[case] expect: TomlError) -> Re
 #[case(
     toml_input(),
     "test",
-    "foo",
-    "baz",
-    (Key::new("foo"), Item::Value(Value::from("world"))),
-    toml_input().replace("foo", "baz"),
-)]
-#[case(
-    toml_input(),
-    "test",
     "bar",
     "baz",
     (Key::new("bar"), Item::Value(Value::from(true))),

--- a/src/tests/config.rs
+++ b/src/tests/config.rs
@@ -141,14 +141,14 @@ fn toml_add_catches_errors(#[case] input: &str, #[case] expect: TomlError) -> Re
     "test",
     "foo",
     (Key::new("foo"), Item::Value(Value::from("world"))),
-    toml_input().replace(r#"foo = "hello""#, ""),
+    toml_input().replace("foo = \"hello\"\n", ""),
 )]
 #[case(
     toml_input(),
     "test",
-    "foo",
+    "bar",
     (Key::new("bar"), Item::Value(Value::from(true))),
-    toml_input().replace(r#"bar = true"#, ""),
+    toml_input().replace("bar = true\n", ""),
 )]
 fn toml_remove_returns_entry(
     #[case] input: String,

--- a/src/tests/config.rs
+++ b/src/tests/config.rs
@@ -4,10 +4,20 @@
 use crate::config::{Toml, TomlError};
 
 use anyhow::Result;
-use indoc::indoc;
+use indoc::{formatdoc, indoc};
 use pretty_assertions::assert_eq;
-use rstest::{rstest, fixture};
+use rstest::{fixture, rstest};
 use toml_edit::{Item, Key, Value};
+
+#[fixture]
+fn toml_input() -> String {
+    String::from(indoc! {r#"
+        # this coment should remain!
+        [test]
+        foo = "hello"
+        bar = true
+    "#})
+}
 
 #[rstest]
 fn toml_parse_parses_good_formatting(
@@ -27,19 +37,19 @@ fn toml_parse_catches_bad_formatting(
 }
 
 #[rstest]
-#[case(
-    indoc! {r#"
-        [foo]
-        bar = "get this"
-    "#},
-    (Key::new("bar"), Item::Value(Value::from("get this")))
-)]
-fn toml_get_returns_entry(#[case] input: &str, #[case] expect: (Key, Item)) -> Result<()> {
-    let toml: Toml = input.parse()?;
-    let (result_key, result_value) = toml.get("foo", "bar")?;
+#[case("test", "foo", (Key::new("foo"), Item::Value(Value::from("hello"))))]
+#[case("test", "bar", (Key::new("bar"), Item::Value(Value::from(true))))]
+fn toml_get_returns_entry(
+    toml_input: String,
+    #[case] table: &str,
+    #[case] key: &str,
+    #[case] expect: (Key, Item),
+) -> Result<()> {
+    let toml: Toml = toml_input.parse()?;
+    let (result_key, result_value) = toml.get(table, key)?;
     let (expect_key, expect_value) = expect;
     assert_eq!(result_key, &expect_key);
-    assert_eq!(result_value.as_str(), expect_value.as_str());
+    assert_eq!(result_value.is_value(), expect_value.is_value());
     Ok(())
 }
 
@@ -59,30 +69,31 @@ fn toml_get_catches_errors(#[case] input: &str, #[case] expect: TomlError) -> Re
 
 #[rstest]
 #[case::add_into_table(
-    indoc! {r#"
-        # add here
-        [foo]
-    "#},
-    indoc! {r#"
-        # add here
-        [foo]
-        bar = "add this"
-    "#}
+    toml_input(),
+    "test",
+    (Key::new("baz"), Item::Value(Value::from("add this"))),
+    formatdoc! {r#"
+        {}baz = "add this"
+    "#, toml_input()}
 )]
 #[case::create_new_table(
-    indoc! {r#"
-        # add new table
-    "#},
-    indoc! {r#"
-        [foo]
-        bar = "add this"
-        # add new table
-    "#},
+    toml_input(),
+    "new_test",
+    (Key::new("baz"), Item::Value(Value::from("add this"))),
+    formatdoc! {r#"
+        {}
+        [new_test]
+        baz = "add this"
+    "#, toml_input()}
 )]
-fn toml_add_new(#[case] input: &str, #[case] expect: &str) -> Result<()> {
+fn toml_add_new_entry(
+    #[case] input: String,
+    #[case] table: &str,
+    #[case] entry: (Key, Item),
+    #[case] expect: String,
+) -> Result<()> {
     let mut toml: Toml = input.parse()?;
-    let entry = (Key::new("bar"), Item::Value(Value::from("add this")));
-    let result = toml.add("foo", entry)?;
+    let result = toml.add(table, entry)?;
     assert_eq!(toml.to_string(), expect);
     assert!(result.is_none());
     Ok(())
@@ -90,21 +101,25 @@ fn toml_add_new(#[case] input: &str, #[case] expect: &str) -> Result<()> {
 
 #[rstest]
 #[case(
-    indoc! {r#"
-        # replace bar value
-        [foo]
-        bar = "this exist"
-    "#},
-    indoc! {r#"
-        # replace bar value
-        [foo]
-        bar = "replaced"
-    "#}
+    toml_input(),
+    "test",
+    (Key::new("foo"), Item::Value(Value::from("replaced"))),
+    toml_input().replace(r#"foo = "hello""#, r#"foo = "replaced""#)
 )]
-fn toml_add_replace(#[case] input: &str, #[case] expect: &str) -> Result<()> {
+#[case(
+    toml_input(),
+    "test",
+    (Key::new("bar"), Item::Value(Value::from(false))),
+    toml_input().replace(r#"bar = true"#, r#"bar = false"#)
+)]
+fn toml_add_replace_entry(
+    #[case] input: String,
+    #[case] table: &str,
+    #[case] entry: (Key, Item),
+    #[case] expect: String,
+) -> Result<()> {
     let mut toml: Toml = input.parse()?;
-    let entry = (Key::new("bar"), Item::Value(Value::from("replaced")));
-    let result = toml.add("foo", entry)?;
+    let result = toml.add(table, entry)?;
     assert_eq!(toml.to_string(), expect);
     assert!(result.is_some());
     Ok(())
@@ -116,6 +131,51 @@ fn toml_add_catches_errors(#[case] input: &str, #[case] expect: TomlError) -> Re
     let mut toml: Toml = input.parse()?;
     let stub = (Key::new("fail"), Item::Value(Value::from("this")));
     let result = toml.add("foo", stub);
+    assert_eq!(result.unwrap_err(), expect);
+    Ok(())
+}
+
+#[rstest]
+#[case(
+    toml_input(),
+    "test",
+    "foo",
+    (Key::new("foo"), Item::Value(Value::from("world"))),
+    toml_input().replace(r#"foo = "hello""#, ""),
+)]
+#[case(
+    toml_input(),
+    "test",
+    "foo",
+    (Key::new("bar"), Item::Value(Value::from(true))),
+    toml_input().replace(r#"bar = true"#, ""),
+)]
+fn toml_remove_returns_entry(
+    #[case] input: String,
+    #[case] table: &str,
+    #[case] key: &str,
+    #[case] expect: (Key, Item),
+    #[case] output: String,
+) -> Result<()> {
+    let mut toml: Toml = input.parse()?;
+    let (return_key, return_value) = toml.remove(table, key)?;
+    let (expect_key, expect_value) = expect;
+    assert_eq!(toml.to_string(), output);
+    assert_eq!(return_key, expect_key);
+    assert_eq!(return_value.is_value(), expect_value.is_value());
+    Ok(())
+}
+
+#[rstest]
+#[case::table_not_found("bar = 'foo not here'", TomlError::TableNotFound { table: "foo".into() })]
+#[case::not_table("foo = 'not a table'", TomlError::NotTable { table: "foo".into() })]
+#[case::entry_not_found(
+    "[foo] # bar not here",
+    TomlError::EntryNotFound { table: "foo".into(), key: "bar".into() }
+)]
+fn toml_remove_catches_errors(#[case] input: &str, #[case] expect: TomlError) -> Result<()> {
+    let toml: Toml = input.parse()?;
+    let result = toml.get("foo", "bar");
     assert_eq!(result.unwrap_err(), expect);
     Ok(())
 }

--- a/src/tests/config.rs
+++ b/src/tests/config.rs
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: MIT
+
+use crate::config::Toml;
+use crate::error::RicerResult;
+
+use indoc::indoc;
+use anyhow::Result;
+use rstest::rstest;
+
+#[rstest]
+fn toml_parse_catches_bad_formatting(
+    #[values("this 'will fail'", "[will # also fail", "not.gonna = [work]")] input: &str,
+) {
+    let result: RicerResult<Toml> = input.parse();
+    assert!(matches!(result, Err(..)));
+}
+
+#[rstest]
+fn toml_parse_parses_good_formatting(
+    #[values(
+        indoc! {r#"
+            [foo]
+            this = "will parse"
+            will.also = "parse"
+        "#}
+    )] input: &str,
+) -> Result<()> {
+    let doc: Toml = input.parse()?;
+    assert_eq!(doc.to_string(), input);
+    Ok(())
+}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
SPDX-License-Identifier: MIT
-->

## Description

Implement TOML parser in `ricer::config` module. Ricer uses TOML for its configuration files.

## Area of Effect

- Module `ricer::config`.
- Module `ricer::error`.

## Tasks

- [x] Define common errors for TOML parsing.
- [x] Add `Toml::get`.
- [x] Add `Toml::add`.
- [x] Add `Toml::rename`.
- [x] Add `Toml::remove`.
