### PR TITLE
Deserialize and serialize TOML data

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -10,9 +10,12 @@
 //! to handle custom hooks for its command set.
 
 mod error;
+mod repository;
+
 
 #[doc(inline)]
 pub use error::*;
+pub use repository::*;
 
 use log::{debug, info, trace};
 use std::fmt;

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,7 +12,6 @@
 mod error;
 mod repository;
 
-
 #[doc(inline)]
 pub use error::*;
 pub use repository::*;

--- a/src/config/repository.rs
+++ b/src/config/repository.rs
@@ -76,6 +76,44 @@ pub struct Bootstrap {
     pub hosts: Option<Vec<String>>,
 }
 
+impl Bootstrap {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn clone(mut self, url: impl Into<String>) -> Self {
+        self.clone = Some(url.into());
+        self
+    }
+
+    pub fn os(mut self, os: OsType) -> Self {
+        self.os = Some(os);
+        self
+    }
+
+    pub fn users<I, S>(mut self, users: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let mut vec = Vec::new();
+        vec.extend(users.into_iter().map(Into::into));
+        self.users = Some(vec);
+        self
+    }
+
+    pub fn hosts<I, S>(mut self, hosts: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let mut vec = Vec::new();
+        vec.extend(hosts.into_iter().map(Into::into));
+        self.hosts = Some(vec);
+        self
+    }
+}
+
 /// Operating System settings.
 ///
 /// Simple enum used to determine the target OS user wants to bootstrap with.

--- a/src/config/repository.rs
+++ b/src/config/repository.rs
@@ -36,6 +36,26 @@ impl Repository {
             bootstrap: Default::default(),
         }
     }
+
+    pub fn branch(mut self, branch: impl Into<String>) -> Self {
+        self.branch = branch.into();
+        self
+    }
+
+    pub fn remote(mut self, remote: impl Into<String>) -> Self {
+        self.remote = remote.into();
+        self
+    }
+
+    pub fn workdir_home(mut self, choice: bool) -> Self {
+        self.workdir_home = choice;
+        self
+    }
+
+    pub fn bootstrap(mut self, bootstrap: Bootstrap) -> Self {
+        self.bootstrap = Some(bootstrap);
+        self
+    }
 }
 
 /// Repository bootstrap configuration settings.

--- a/src/config/repository.rs
+++ b/src/config/repository.rs
@@ -63,6 +63,18 @@ pub enum OsType {
     Windows,
 }
 
+impl From<&str> for OsType {
+    fn from(data: &str) -> Self {
+        match data {
+            "any" => Self::Any,
+            "unix" => Self::Unix,
+            "macos" => Self::MacOs,
+            "windows" => Self::Windows,
+            &_ => Self::Any,
+        }
+    }
+}
+
 impl fmt::Display for OsType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/src/config/repository.rs
+++ b/src/config/repository.rs
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: MIT
+
+/// Repository configuration settings.
+///
+/// Intermediary structure meant to help make it easier to deserialize and
+/// serialize repository configuration file data.
+#[derive(Debug, Default, Eq, PartialEq, Clone)]
+pub struct Repository {
+    pub name: String,
+
+    pub branch: String,
+
+    pub remote: String,
+
+    pub workdir_home: bool,
+
+    pub bootstrap: Option<Bootstrap>,
+}

--- a/src/config/repository.rs
+++ b/src/config/repository.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: MIT
 
+use std::fmt;
+
 /// Repository configuration settings.
 ///
 /// Intermediary structure meant to help make it easier to deserialize and
@@ -59,4 +61,15 @@ pub enum OsType {
 
     /// Bootstrap to Windows system only.
     Windows,
+}
+
+impl fmt::Display for OsType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OsType::Any => write!(f, "any"),
+            OsType::Unix => write!(f, "unix"),
+            OsType::MacOs => write!(f, "macos"),
+            OsType::Windows => write!(f, "windows"),
+        }
+    }
 }

--- a/src/config/repository.rs
+++ b/src/config/repository.rs
@@ -7,13 +7,56 @@
 /// serialize repository configuration file data.
 #[derive(Debug, Default, Eq, PartialEq, Clone)]
 pub struct Repository {
+    /// Name of repository.
     pub name: String,
 
+    /// Default branch.
     pub branch: String,
 
+    /// Default remote.
     pub remote: String,
 
+    /// Flag to determine if repository's working directory is the user's home
+    /// directory through _fake bare_ technique.
     pub workdir_home: bool,
 
+    /// Bootstrap configuration for repository.
     pub bootstrap: Option<Bootstrap>,
+}
+
+/// Repository bootstrap configuration settings.
+#[derive(Debug, Default, Eq, PartialEq, Clone)]
+pub struct Bootstrap {
+    /// URL to clone repository from.
+    pub clone: Option<String>,
+
+    /// Bootstrap repository if and only if user is using a specific OS.
+    pub os: Option<OsType>,
+
+    /// Bootstrap repository if and only if user is logged on to a specific
+    /// set of user accounts.
+    pub users: Option<Vec<String>>,
+
+    /// Bootstrap repository if and only if user is logged on to a specific
+    /// set of hosts.
+    pub hosts: Option<Vec<String>>,
+}
+
+/// Operating System settings.
+///
+/// Simple enum used to determine the target OS user wants to bootstrap with.
+#[derive(Debug, Default, Eq, PartialEq, Copy, Clone)]
+pub enum OsType {
+    /// Bootstrap to any operating system.
+    #[default]
+    Any,
+
+    /// Bootstrap to Unix-like systems only.
+    Unix,
+
+    /// Bootstrap to MacOS systems only.
+    MacOs,
+
+    /// Bootstrap to Windows system only.
+    Windows,
 }

--- a/src/config/repository.rs
+++ b/src/config/repository.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 use std::fmt;
-use toml_edit::{Table, Key, Array, Value, Item};
-use toml_edit::visit::{Visit, visit_table_like_kv};
+use toml_edit::visit::{visit_table_like_kv, Visit};
+use toml_edit::{Array, Item, Key, Table, Value};
 
 /// Repository configuration settings.
 ///
@@ -89,16 +89,16 @@ impl Repository {
 }
 
 fn repo_toml<'toml>(entry: (&'toml Key, &'toml Item)) -> Repository {
-   let (key, value) = entry;
-   let mut bootstrap = Bootstrap::new();
-   let mut repo = Repository::new(key.get());
-   bootstrap.visit_item(value);
-   repo.visit_item(value);
+    let (key, value) = entry;
+    let mut bootstrap = Bootstrap::new();
+    let mut repo = Repository::new(key.get());
+    bootstrap.visit_item(value);
+    repo.visit_item(value);
 
-   if bootstrap.is_empty() {
-       repo = repo.bootstrap(bootstrap);
-   }
-   repo
+    if !bootstrap.is_empty() {
+        repo = repo.bootstrap(bootstrap);
+    }
+    repo
 }
 
 impl<'toml> From<(&'toml Key, &'toml Item)> for Repository {

--- a/src/config/repository.rs
+++ b/src/config/repository.rs
@@ -26,6 +26,18 @@ pub struct Repository {
     pub bootstrap: Option<Bootstrap>,
 }
 
+impl Repository {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            branch: Default::default(),
+            remote: Default::default(),
+            workdir_home: Default::default(),
+            bootstrap: Default::default(),
+        }
+    }
+}
+
 /// Repository bootstrap configuration settings.
 #[derive(Debug, Default, Eq, PartialEq, Clone)]
 pub struct Bootstrap {

--- a/src/tests/config.rs
+++ b/src/tests/config.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: MIT
 
+mod repository;
+
 use crate::config::{Toml, TomlError};
 
 use anyhow::Result;

--- a/src/tests/config/repository.rs
+++ b/src/tests/config/repository.rs
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: MIT
+
+use crate::config::{Bootstrap, OsType, Repository};
+
+use anyhow::Result;
+use indoc::indoc;
+use pretty_assertions::assert_eq;
+use rstest::rstest;
+use toml_edit::{DocumentMut, Item, Key};
+
+fn setup_toml_doc(entry: (Key, Item)) -> Result<DocumentMut> {
+    let mut doc: DocumentMut = "[repos]".parse()?;
+    let table = doc.get_mut("repos").unwrap();
+    let table = table.as_table_mut().unwrap();
+    let (key, item) = entry;
+    table.insert_formatted(&key, item);
+    table.set_implicit(true);
+    Ok(doc)
+}
+
+#[rstest]
+#[case::no_bootstrap(
+    Repository::new("vim")
+        .branch("master")
+        .remote("origin")
+        .workdir_home(true),
+    indoc! {r#"
+        [repos.vim]
+        branch = "master"
+        remote = "origin"
+        workdir_home = true
+    "#}
+)]
+#[case::no_bootstrap(
+    Repository::new("vim")
+        .branch("master")
+        .remote("origin")
+        .workdir_home(true)
+        .bootstrap(
+            Bootstrap::new()
+                .clone("https://github.com/awkless/vim.git")
+                .os(OsType::Unix)
+                .users(["awkless", "sedgwick"])
+                .hosts(["lovelace", "turing"])
+        ),
+    indoc! {r#"
+        [repos.vim]
+        branch = "master"
+        remote = "origin"
+        workdir_home = true
+
+        [repos.vim.bootstrap]
+        clone = "https://github.com/awkless/vim.git"
+        os = "unix"
+        users = ["awkless", "sedgwick"]
+        hosts = ["lovelace", "turing"]
+    "#}
+)]
+fn to_toml_serializes(#[case] repo: Repository, #[case] expect: &str) -> Result<()> {
+    let doc = setup_toml_doc(repo.to_toml())?;
+    assert_eq!(doc.to_string(), expect);
+    Ok(())
+}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
SPDX-License-Identifier: MIT
-->

## Description

Implement way to serialize and deserialize TOML document entries into usable data structures in Rust.

## Area of Effect

- Module `ricer::config`.

## Tasks

- [x] Add `Repository`.
- [x] Add `Bootstrap`.
- [x] Add `Repository::from` to deserialize TOML entries.
- [x] Add `Repository::to_toml` to serialize configuration data to TOML entry.
