### PR TITLE
Implement command hook serialization and deserialization

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -2,4 +2,3 @@
 # SPDX-License-Identifier: CC0-1.0
 
 max_width = 100
-use_small_heuristics = "Max"

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,10 +10,12 @@
 //! to handle custom hooks for its command set.
 
 mod error;
+mod hook;
 mod repository;
 
 #[doc(inline)]
 pub use error::*;
+pub use hook::*;
 pub use repository::*;
 
 use log::{debug, info, trace};

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,7 +38,9 @@ pub struct Toml {
 impl Toml {
     pub fn new() -> Self {
         trace!("Construct new TOML parser");
-        Self { doc: DocumentMut::new() }
+        Self {
+            doc: DocumentMut::new(),
+        }
     }
 
     /// Add TOML entry into document.
@@ -62,7 +64,11 @@ impl Toml {
         entry: (Key, Item),
     ) -> Result<Option<(Key, Item)>, TomlError> {
         let (key, value) = entry;
-        info!("Add TOML entry '{}' to '{}' table", key.get(), table.as_ref());
+        info!(
+            "Add TOML entry '{}' to '{}' table",
+            key.get(),
+            table.as_ref()
+        );
         let entry = match self.get_table_mut(table.as_ref()) {
             Ok(table) => table,
             Err(TomlError::TableNotFound { .. }) => {
@@ -97,12 +103,18 @@ impl Toml {
     where
         S: AsRef<str>,
     {
-        info!("Get TOML entry '{}' from '{}' table", key.as_ref(), table.as_ref());
+        info!(
+            "Get TOML entry '{}' from '{}' table",
+            key.as_ref(),
+            table.as_ref()
+        );
         let entry = self.get_table(table.as_ref())?;
-        let entry = entry.get_key_value(key.as_ref()).ok_or_else(|| TomlError::EntryNotFound {
-            table: table.as_ref().into(),
-            key: key.as_ref().into(),
-        })?;
+        let entry = entry
+            .get_key_value(key.as_ref())
+            .ok_or_else(|| TomlError::EntryNotFound {
+                table: table.as_ref().into(),
+                key: key.as_ref().into(),
+            })?;
         Ok(entry)
     }
 
@@ -127,9 +139,13 @@ impl Toml {
         S: AsRef<str>,
     {
         let entry = self.get_table_mut(table.as_ref())?;
-        let (old_key, old_item) = entry.remove_entry(from.as_ref()).ok_or_else(|| {
-            TomlError::EntryNotFound { table: table.as_ref().into(), key: from.as_ref().into() }
-        })?;
+        let (old_key, old_item) =
+            entry
+                .remove_entry(from.as_ref())
+                .ok_or_else(|| TomlError::EntryNotFound {
+                    table: table.as_ref().into(),
+                    key: from.as_ref().into(),
+                })?;
         let new_key = Key::new(to.as_ref()).with_leaf_decor(old_key.leaf_decor().clone());
         entry.insert_formatted(&new_key, old_item.clone());
         Ok((old_key, old_item))
@@ -156,10 +172,12 @@ impl Toml {
         S: AsRef<str>,
     {
         let entry = self.get_table_mut(table.as_ref())?;
-        let entry = entry.remove_entry(key.as_ref()).ok_or_else(|| TomlError::EntryNotFound {
-            table: table.as_ref().into(),
-            key: key.as_ref().into(),
-        })?;
+        let entry = entry
+            .remove_entry(key.as_ref())
+            .ok_or_else(|| TomlError::EntryNotFound {
+                table: table.as_ref().into(),
+                key: key.as_ref().into(),
+            })?;
         Ok(entry)
     }
 
@@ -178,9 +196,13 @@ impl Toml {
     /// [`TomlError::NotTable`]: crate::config::TomlError::NotTable
     pub(crate) fn get_table(&self, key: &str) -> Result<&Table, TomlError> {
         debug!("Get TOML table '{key}'");
-        let table =
-            self.doc.get(key).ok_or_else(|| TomlError::TableNotFound { table: key.into() })?;
-        let table = table.as_table().ok_or_else(|| TomlError::NotTable { table: key.into() })?;
+        let table = self
+            .doc
+            .get(key)
+            .ok_or_else(|| TomlError::TableNotFound { table: key.into() })?;
+        let table = table
+            .as_table()
+            .ok_or_else(|| TomlError::NotTable { table: key.into() })?;
         Ok(table)
     }
 
@@ -199,10 +221,13 @@ impl Toml {
     /// [`TomlError::NotTable`]: crate::config::TomlError::NotTable
     pub(crate) fn get_table_mut(&mut self, key: &str) -> Result<&mut Table, TomlError> {
         debug!("Get mutable TOML table '{key}'");
-        let table =
-            self.doc.get_mut(key).ok_or_else(|| TomlError::TableNotFound { table: key.into() })?;
-        let table =
-            table.as_table_mut().ok_or_else(|| TomlError::NotTable { table: key.into() })?;
+        let table = self
+            .doc
+            .get_mut(key)
+            .ok_or_else(|| TomlError::TableNotFound { table: key.into() })?;
+        let table = table
+            .as_table_mut()
+            .ok_or_else(|| TomlError::NotTable { table: key.into() })?;
         Ok(table)
     }
 }
@@ -217,7 +242,9 @@ impl FromStr for Toml {
     type Err = TomlError;
 
     fn from_str(data: &str) -> Result<Self, Self::Err> {
-        let doc: DocumentMut = data.parse().map_err(|err| TomlError::BadParse { source: err })?;
+        let doc: DocumentMut = data
+            .parse()
+            .map_err(|err| TomlError::BadParse { source: err })?;
         Ok(Self { doc })
     }
 }

--- a/src/config/hook.rs
+++ b/src/config/hook.rs
@@ -23,8 +23,9 @@ impl CommandHook {
         Self { cmd: cmd.into(), hooks: Default::default() }
     }
 
-    pub fn add_hook(&mut self, hook: Hook) {
+    pub fn add_hook(mut self, hook: Hook) -> Self {
         self.hooks.push(hook);
+        self
     }
 
     pub fn to_toml(&self) -> (Key, Item) {
@@ -90,7 +91,7 @@ impl<'toml> Visit<'toml> for CommandHook {
         let hook = if let Some(pre) = pre { hook.pre(pre) } else { hook };
         let hook = if let Some(post) = post { hook.post(post) } else { hook };
         let hook = if let Some(workdir) = workdir { hook.workdir(workdir) } else { hook };
-        self.add_hook(hook);
+        self.hooks.push(hook);
 
         visit_inline_table(self, node);
     }

--- a/src/config/hook.rs
+++ b/src/config/hook.rs
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: MIT
+
+/// Command hook settings.
+///
+/// An intermediary structure to help deserialize and serialize command hook
+/// from Ricer's command hook configuration file.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct CommandHook {
+    /// Name of command to bind hook definitions too.
+    pub cmd: String,
+
+    /// Array of hook definitions to execute.
+    pub hooks: Vec<Hook>,
+}

--- a/src/config/hook.rs
+++ b/src/config/hook.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 use std::path::PathBuf;
-use toml_edit::{Array, Value, Key, Item, InlineTable};
-use toml_edit::visit::{Visit, visit_inline_table};
+use toml_edit::visit::{visit_inline_table, Visit};
+use toml_edit::{Array, InlineTable, Item, Key, Value};
 
 /// Command hook settings.
 ///
@@ -20,7 +20,10 @@ pub struct CommandHook {
 
 impl CommandHook {
     pub fn new(cmd: impl Into<String>) -> Self {
-        Self { cmd: cmd.into(), hooks: Default::default() }
+        Self {
+            cmd: cmd.into(),
+            hooks: Default::default(),
+        }
     }
 
     pub fn add_hook(mut self, hook: Hook) -> Self {
@@ -49,7 +52,10 @@ impl CommandHook {
             }
 
             if let Some(workdir) = &hook.workdir {
-                inline.insert("workdir", Value::from(String::from(workdir.to_string_lossy())));
+                inline.insert(
+                    "workdir",
+                    Value::from(String::from(workdir.to_string_lossy())),
+                );
             }
 
             tables.push_formatted(Value::from(inline));
@@ -83,14 +89,38 @@ impl From<(Key, Item)> for CommandHook {
 
 impl<'toml> Visit<'toml> for CommandHook {
     fn visit_inline_table(&mut self, node: &'toml InlineTable) {
-        let pre = if let Some(pre) = node.get("pre") { pre.as_str() } else { None };
-        let post = if let Some(post) = node.get("post") { post.as_str() } else { None };
-        let workdir = if let Some(workdir) = node.get("workdir") { workdir.as_str() } else { None };
+        let pre = if let Some(pre) = node.get("pre") {
+            pre.as_str()
+        } else {
+            None
+        };
+        let post = if let Some(post) = node.get("post") {
+            post.as_str()
+        } else {
+            None
+        };
+        let workdir = if let Some(workdir) = node.get("workdir") {
+            workdir.as_str()
+        } else {
+            None
+        };
 
         let hook = Hook::new();
-        let hook = if let Some(pre) = pre { hook.pre(pre) } else { hook };
-        let hook = if let Some(post) = post { hook.post(post) } else { hook };
-        let hook = if let Some(workdir) = workdir { hook.workdir(workdir) } else { hook };
+        let hook = if let Some(pre) = pre {
+            hook.pre(pre)
+        } else {
+            hook
+        };
+        let hook = if let Some(post) = post {
+            hook.post(post)
+        } else {
+            hook
+        };
+        let hook = if let Some(workdir) = workdir {
+            hook.workdir(workdir)
+        } else {
+            hook
+        };
         self.hooks.push(hook);
 
         visit_inline_table(self, node);

--- a/src/config/hook.rs
+++ b/src/config/hook.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 use std::path::PathBuf;
-use toml_edit::{Key, Item};
+use toml_edit::{Key, Item, InlineTable};
+use toml_edit::visit::{Visit, visit_inline_table};
 
 /// Command hook settings.
 ///
@@ -24,6 +25,42 @@ impl CommandHook {
 
     pub fn add_hook(&mut self, hook: Hook) {
         self.hooks.push(hook);
+    }
+}
+
+fn from_toml<'toml>(entry: (&'toml Key, &'toml Item)) -> CommandHook {
+    let (key, value) = entry;
+    let mut cmd_hook = CommandHook::new(key.get());
+    cmd_hook.visit_item(value);
+    cmd_hook
+}
+
+impl<'toml> From<(&'toml Key, &'toml Item)> for CommandHook {
+    fn from(entry: (&'toml Key, &'toml Item)) -> Self {
+        from_toml(entry)
+    }
+}
+
+impl From<(Key, Item)> for CommandHook {
+    fn from(entry: (Key, Item)) -> Self {
+        let (key, value) = entry;
+        from_toml((&key, &value))
+    }
+}
+
+impl<'toml> Visit<'toml> for CommandHook {
+    fn visit_inline_table(&mut self, node: &'toml InlineTable) {
+        let pre = if let Some(pre) = node.get("pre") { pre.as_str() } else { None };
+        let post = if let Some(post) = node.get("post") { post.as_str() } else { None };
+        let workdir = if let Some(workdir) = node.get("workdir") { workdir.as_str() } else { None };
+
+        let hook = Hook::new();
+        let hook = if let Some(pre) = pre { hook.pre(pre) } else { hook };
+        let hook = if let Some(post) = post { hook.post(post) } else { hook };
+        let hook = if let Some(workdir) = workdir { hook.workdir(workdir) } else { hook };
+        self.add_hook(hook);
+
+        visit_inline_table(self, node);
     }
 }
 

--- a/src/config/hook.rs
+++ b/src/config/hook.rs
@@ -21,6 +21,10 @@ impl CommandHook {
     pub fn new(cmd: impl Into<String>) -> Self {
         Self { cmd: cmd.into(), hooks: Default::default() }
     }
+
+    pub fn add_hook(&mut self, hook: Hook) {
+        self.hooks.push(hook);
+    }
 }
 
 /// Hook definition settings.

--- a/src/config/hook.rs
+++ b/src/config/hook.rs
@@ -31,3 +31,24 @@ pub struct Hook {
     /// Set working directory of hook script.
     pub workdir: Option<PathBuf>,
 }
+
+impl Hook {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn pre(mut self, script: impl Into<String>) -> Self {
+        self.pre = Some(script.into());
+        self
+    }
+
+    pub fn post(mut self, script: impl Into<String>) -> Self {
+        self.post = Some(script.into());
+        self
+    }
+
+    pub fn workdir(mut self, path: impl Into<PathBuf>) -> Self {
+        self.workdir = Some(path.into());
+        self
+    }
+}

--- a/src/config/hook.rs
+++ b/src/config/hook.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: MIT
 
+use std::path::PathBuf;
+
 /// Command hook settings.
 ///
 /// An intermediary structure to help deserialize and serialize command hook
@@ -12,4 +14,20 @@ pub struct CommandHook {
 
     /// Array of hook definitions to execute.
     pub hooks: Vec<Hook>,
+}
+
+/// Hook definition settings.
+///
+/// An intermediary structure to help deserialize and serialize hook entries
+/// for command hook settings in command hook configuration file.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct Hook {
+    /// Execute hook script _before_ command itself.
+    pub pre: Option<String>,
+
+    /// Execute hook script _after_ command itself.
+    pub post: Option<String>,
+
+    /// Set working directory of hook script.
+    pub workdir: Option<PathBuf>,
 }

--- a/src/config/hook.rs
+++ b/src/config/hook.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 use std::path::PathBuf;
+use toml_edit::{Key, Item};
 
 /// Command hook settings.
 ///
@@ -14,6 +15,12 @@ pub struct CommandHook {
 
     /// Array of hook definitions to execute.
     pub hooks: Vec<Hook>,
+}
+
+impl CommandHook {
+    pub fn new(cmd: impl Into<String>) -> Self {
+        Self { cmd: cmd.into(), hooks: Default::default() }
+    }
 }
 
 /// Hook definition settings.

--- a/src/config/repository.rs
+++ b/src/config/repository.rs
@@ -204,7 +204,10 @@ impl<'toml> Visit<'toml> for Bootstrap {
                     let data = users
                         .into_iter()
                         .map(|s| {
-                            s.as_str().unwrap().trim_matches(|c| c == '\"' || c == '\'').to_string()
+                            s.as_str()
+                                .unwrap()
+                                .trim_matches(|c| c == '\"' || c == '\'')
+                                .to_string()
                         })
                         .collect();
                     self.users = Some(data)
@@ -215,7 +218,10 @@ impl<'toml> Visit<'toml> for Bootstrap {
                     let data = hosts
                         .into_iter()
                         .map(|s| {
-                            s.as_str().unwrap().trim_matches(|c| c == '\"' || c == '\'').to_string()
+                            s.as_str()
+                                .unwrap()
+                                .trim_matches(|c| c == '\"' || c == '\'')
+                                .to_string()
                         })
                         .collect();
                     self.hosts = Some(data)

--- a/src/context.rs
+++ b/src/context.rs
@@ -65,7 +65,11 @@ pub struct BootstrapContext {
 
 impl From<Cli> for BootstrapContext {
     fn from(opts: Cli) -> Self {
-        let Cli { shared_opts, cmd_set, .. } = opts;
+        let Cli {
+            shared_opts,
+            cmd_set,
+            ..
+        } = opts;
         let cmd_set = match cmd_set {
             CommandSet::Bootstrap(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'bootstrap'!"),
@@ -89,13 +93,21 @@ pub struct CloneContext {
 
 impl From<Cli> for CloneContext {
     fn from(opts: Cli) -> Self {
-        let Cli { shared_opts, cmd_set, .. } = opts;
+        let Cli {
+            shared_opts,
+            cmd_set,
+            ..
+        } = opts;
         let cmd_set = match cmd_set {
             CommandSet::Clone(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'clone'!"),
         };
 
-        Self { remote: cmd_set.remote, repo: cmd_set.repo, shared: shared_opts.into() }
+        Self {
+            remote: cmd_set.remote,
+            repo: cmd_set.repo,
+            shared: shared_opts.into(),
+        }
     }
 }
 
@@ -108,13 +120,21 @@ pub struct CommitContext {
 
 impl From<Cli> for CommitContext {
     fn from(opts: Cli) -> Self {
-        let Cli { shared_opts, cmd_set, .. } = opts;
+        let Cli {
+            shared_opts,
+            cmd_set,
+            ..
+        } = opts;
         let cmd_set = match cmd_set {
             CommandSet::Commit(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'commit'!"),
         };
 
-        Self { fixup: cmd_set.fixup, message: cmd_set.message, shared: shared_opts.into() }
+        Self {
+            fixup: cmd_set.fixup,
+            message: cmd_set.message,
+            shared: shared_opts.into(),
+        }
     }
 }
 
@@ -126,13 +146,20 @@ pub struct DeleteContext {
 
 impl From<Cli> for DeleteContext {
     fn from(opts: Cli) -> Self {
-        let Cli { shared_opts, cmd_set, .. } = opts;
+        let Cli {
+            shared_opts,
+            cmd_set,
+            ..
+        } = opts;
         let cmd_set = match cmd_set {
             CommandSet::Delete(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'delete'!"),
         };
 
-        Self { repo: cmd_set.repo, shared: shared_opts.into() }
+        Self {
+            repo: cmd_set.repo,
+            shared: shared_opts.into(),
+        }
     }
 }
 
@@ -144,13 +171,20 @@ pub struct EnterContext {
 
 impl From<Cli> for EnterContext {
     fn from(opts: Cli) -> Self {
-        let Cli { shared_opts, cmd_set, .. } = opts;
+        let Cli {
+            shared_opts,
+            cmd_set,
+            ..
+        } = opts;
         let cmd_set = match cmd_set {
             CommandSet::Enter(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'enter'!"),
         };
 
-        Self { repo: cmd_set.repo, shared: shared_opts.into() }
+        Self {
+            repo: cmd_set.repo,
+            shared: shared_opts.into(),
+        }
     }
 }
 
@@ -165,7 +199,11 @@ pub struct InitContext {
 
 impl From<Cli> for InitContext {
     fn from(opts: Cli) -> Self {
-        let Cli { shared_opts, cmd_set, .. } = opts;
+        let Cli {
+            shared_opts,
+            cmd_set,
+            ..
+        } = opts;
         let cmd_set = match cmd_set {
             CommandSet::Init(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'init'!"),
@@ -190,13 +228,21 @@ pub struct ListContext {
 
 impl From<Cli> for ListContext {
     fn from(opts: Cli) -> Self {
-        let Cli { shared_opts, cmd_set, .. } = opts;
+        let Cli {
+            shared_opts,
+            cmd_set,
+            ..
+        } = opts;
         let cmd_set = match cmd_set {
             CommandSet::List(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'list'!"),
         };
 
-        Self { tracked: cmd_set.tracked, untracked: cmd_set.untracked, shared: shared_opts.into() }
+        Self {
+            tracked: cmd_set.tracked,
+            untracked: cmd_set.untracked,
+            shared: shared_opts.into(),
+        }
     }
 }
 
@@ -209,13 +255,21 @@ pub struct PushContext {
 
 impl From<Cli> for PushContext {
     fn from(opts: Cli) -> Self {
-        let Cli { shared_opts, cmd_set, .. } = opts;
+        let Cli {
+            shared_opts,
+            cmd_set,
+            ..
+        } = opts;
         let cmd_set = match cmd_set {
             CommandSet::Push(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'push'!"),
         };
 
-        Self { remote: cmd_set.remote, branch: cmd_set.branch, shared: shared_opts.into() }
+        Self {
+            remote: cmd_set.remote,
+            branch: cmd_set.branch,
+            shared: shared_opts.into(),
+        }
     }
 }
 
@@ -228,13 +282,21 @@ pub struct PullContext {
 
 impl From<Cli> for PullContext {
     fn from(opts: Cli) -> Self {
-        let Cli { shared_opts, cmd_set, .. } = opts;
+        let Cli {
+            shared_opts,
+            cmd_set,
+            ..
+        } = opts;
         let cmd_set = match cmd_set {
             CommandSet::Pull(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'pull'!"),
         };
 
-        Self { remote: cmd_set.remote, branch: cmd_set.branch, shared: shared_opts.into() }
+        Self {
+            remote: cmd_set.remote,
+            branch: cmd_set.branch,
+            shared: shared_opts.into(),
+        }
     }
 }
 
@@ -247,13 +309,21 @@ pub struct RenameContext {
 
 impl From<Cli> for RenameContext {
     fn from(opts: Cli) -> Self {
-        let Cli { shared_opts, cmd_set, .. } = opts;
+        let Cli {
+            shared_opts,
+            cmd_set,
+            ..
+        } = opts;
         let cmd_set = match cmd_set {
             CommandSet::Rename(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'rename'!"),
         };
 
-        Self { from: cmd_set.from, to: cmd_set.to, shared: shared_opts.into() }
+        Self {
+            from: cmd_set.from,
+            to: cmd_set.to,
+            shared: shared_opts.into(),
+        }
     }
 }
 
@@ -265,13 +335,20 @@ pub struct StatusContext {
 
 impl From<Cli> for StatusContext {
     fn from(opts: Cli) -> Self {
-        let Cli { shared_opts, cmd_set, .. } = opts;
+        let Cli {
+            shared_opts,
+            cmd_set,
+            ..
+        } = opts;
         let cmd_set = match cmd_set {
             CommandSet::Status(opts) => opts,
             _ => unreachable!("This should never happen. The command is not 'status'!"),
         };
 
-        Self { terse: cmd_set.terse, shared: shared_opts.into() }
+        Self {
+            terse: cmd_set.terse,
+            shared: shared_opts.into(),
+        }
     }
 }
 
@@ -299,7 +376,10 @@ impl From<Cli> for GitContext {
             _ => unreachable!("This should not happen. The command is not git shortcut!"),
         };
 
-        Self { repo: cmd_set[0].clone(), git_args: cmd_set[1..].to_vec() }
+        Self {
+            repo: cmd_set[0].clone(),
+            git_args: cmd_set[1..].to_vec(),
+        }
     }
 }
 
@@ -315,7 +395,9 @@ pub struct SharedContext {
 
 impl From<SharedOptions> for SharedContext {
     fn from(opts: SharedOptions) -> Self {
-        Self { run_hook: opts.run_hook }
+        Self {
+            run_hook: opts.run_hook,
+        }
     }
 }
 

--- a/src/tests/config.rs
+++ b/src/tests/config.rs
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: MIT
 
-mod repository;
 mod hook;
+mod repository;
 
 use crate::config::{Toml, TomlError};
 

--- a/src/tests/config.rs
+++ b/src/tests/config.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 mod repository;
+mod hook;
 
 use crate::config::{Toml, TomlError};
 

--- a/src/tests/config/hook.rs
+++ b/src/tests/config/hook.rs
@@ -6,8 +6,8 @@ use crate::config::{CommandHook, Hook};
 use anyhow::Result;
 use indoc::indoc;
 use pretty_assertions::assert_eq;
-use toml_edit::{DocumentMut, Item, Key};
 use rstest::rstest;
+use toml_edit::{DocumentMut, Item, Key};
 
 fn setup_toml_doc(entry: (Key, Item)) -> Result<DocumentMut> {
     let mut doc: DocumentMut = "[hooks]".parse()?;
@@ -49,7 +49,13 @@ fn to_toml_serializes(#[case] cmd_hook: CommandHook, #[case] expect: &str) -> Re
 )]
 fn from_deserializes(#[case] expect: CommandHook) -> Result<()> {
     let doc = setup_toml_doc(expect.to_toml())?;
-    let result = CommandHook::from(doc["hooks"].as_table().unwrap().get_key_value("commit").unwrap());
+    let result = CommandHook::from(
+        doc["hooks"]
+            .as_table()
+            .unwrap()
+            .get_key_value("commit")
+            .unwrap(),
+    );
     assert_eq!(result, expect);
     Ok(())
 }

--- a/src/tests/config/hook.rs
+++ b/src/tests/config/hook.rs
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: MIT
+
+use crate::config::{CommandHook, Hook};
+
+use anyhow::Result;
+use indoc::indoc;
+use pretty_assertions::assert_eq;
+use toml_edit::{DocumentMut, Item, Key};
+use rstest::rstest;
+
+fn setup_toml_doc(entry: (Key, Item)) -> Result<DocumentMut> {
+    let mut doc: DocumentMut = "[hooks]".parse()?;
+    let table = doc.get_mut("hooks").unwrap();
+    let table = table.as_table_mut().unwrap();
+    let (key, item) = entry;
+    table.insert_formatted(&key, item);
+    table.set_implicit(true);
+    Ok(doc)
+}
+
+#[rstest]
+#[case(
+    CommandHook::new("commit")
+        .add_hook(Hook::new().pre("hook.sh").post("hook.sh").workdir("/some/path"))
+        .add_hook(Hook::new().pre("hook.sh"))
+        .add_hook(Hook::new().post("hook.sh")),
+    indoc! {r#"
+        [hooks]
+        commit = [
+            { pre = "hook.sh", post = "hook.sh", workdir = "/some/path" },
+            { pre = "hook.sh" },
+            { post = "hook.sh" }
+        ]
+    "#}
+)]
+fn to_toml_serializes(#[case] cmd_hook: CommandHook, #[case] expect: &str) -> Result<()> {
+    let doc = setup_toml_doc(cmd_hook.to_toml())?;
+    assert_eq!(doc.to_string(), expect);
+    Ok(())
+}
+
+#[rstest]
+#[case(
+    CommandHook::new("commit")
+        .add_hook(Hook::new().pre("hook.sh").post("hook.sh").workdir("/some/path"))
+        .add_hook(Hook::new().pre("hook.sh"))
+        .add_hook(Hook::new().post("hook.sh"))
+)]
+fn from_deserializes(#[case] expect: CommandHook) -> Result<()> {
+    let doc = setup_toml_doc(expect.to_toml())?;
+    let result = CommandHook::from(doc["hooks"].as_table().unwrap().get_key_value("commit").unwrap());
+    assert_eq!(result, expect);
+    Ok(())
+}

--- a/src/tests/config/repository.rs
+++ b/src/tests/config/repository.rs
@@ -85,7 +85,13 @@ fn to_toml_serializes(#[case] repo: Repository, #[case] expect: &str) -> Result<
 )]
 fn from_entry_deserializes(#[case] expect: Repository) -> Result<()> {
     let doc = setup_toml_doc(expect.to_toml())?;
-    let result = Repository::from(doc["repos"].as_table().unwrap().get_key_value("vim").unwrap());
+    let result = Repository::from(
+        doc["repos"]
+            .as_table()
+            .unwrap()
+            .get_key_value("vim")
+            .unwrap(),
+    );
     assert_eq!(result, expect);
     Ok(())
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
SPDX-License-Identifier: MIT
-->

## Description

Implement `CommandHook` and `Hook` to perform serialization and deserialization for configuration file data pertaining for command hooks.

## Area of Effect

- Module `ricer::config`.