### PR TITLE
Add locator API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,6 +497,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "libssh2-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,6 +633,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking_lot"
@@ -762,6 +799,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,6 +851,7 @@ dependencies = [
  "anyhow",
  "clap",
  "clap-verbosity-flag",
+ "directories",
  "env_logger",
  "git2",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ doc = false
 anyhow = "~1.0.90"
 clap = { version = "~4.5.20", features = ["derive"] }
 clap-verbosity-flag = "~2.2.2"
+directories = "~5.0.1"
 env_logger = "~0.11.5"
 indoc = "~2.0.5"
 git2 = "~0.19.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@
 pub mod cli;
 pub mod config;
 pub mod context;
+pub mod manager;
 
 #[cfg(test)]
 mod tests;

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: MIT
+
+mod error;
+mod locator;
+
+#[doc(inline)]
+pub use error::*;
+pub use locator::*;

--- a/src/manager/error.rs
+++ b/src/manager/error.rs
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: MIT
+
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+pub enum LocatorError {
+    #[error("Cannot determine path to home directory")]
+    NoWayHome,
+}

--- a/src/manager/locator.rs
+++ b/src/manager/locator.rs
@@ -2,13 +2,63 @@
 // SPDX-License-Identifier: MIT
 
 use directories::ProjectDirs;
-use log::trace;
-use std::path::Path;
+use log::{debug, trace};
+use std::path::{PathBuf, Path};
 
 #[cfg(test)]
 use mockall::automock;
 
 use crate::manager::LocatorError;
+
+/// Configuration directory locator.
+///
+/// Locates absolute paths to the three special directories that Ricer
+/// relies on.
+#[cfg_attr(test, automock)]
+pub trait DirLocator {
+    /// Expected absolute path to configuration file directory.
+    fn config_dir(&self) -> &Path;
+
+    /// Expected absolute path to hook script directory.
+    fn hooks_dir(&self) -> &Path;
+
+    /// Expected absolute path to repository directory.
+    fn repos_dir(&self) -> &Path;
+}
+
+pub struct DefaultDirLocator {
+    config_dir: PathBuf,
+    hooks_dir: PathBuf,
+    repos_dir: PathBuf,
+}
+
+impl DefaultDirLocator {
+    pub fn new_locate(layout: &impl DirLayout) -> Self {
+        trace!("Construct configuration directory locator");
+        let config_dir = layout.behavior_dir().join("ricer");
+        let hooks_dir = config_dir.join("hooks");
+        let repos_dir = layout.repo_dir().join("ricer");
+
+        debug!("Configuration directory located at '{}'", config_dir.display());
+        debug!("Hook script directory located at '{}'", hooks_dir.display());
+        debug!("Repository directory located at '{}'", repos_dir.display());
+        Self { config_dir, hooks_dir, repos_dir }
+    }
+}
+
+impl DirLocator for DefaultDirLocator {
+    fn config_dir(&self) -> &Path {
+        self.config_dir.as_path()
+    }
+
+    fn hooks_dir(&self) -> &Path {
+        self.hooks_dir.as_path()
+    }
+
+    fn repos_dir(&self) -> &Path {
+        self.repos_dir.as_path()
+    }
+}
 
 /// Handle different configuration directory layouts.
 ///

--- a/src/manager/locator.rs
+++ b/src/manager/locator.rs
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: MIT
+
+#[cfg(test)]
+use mockall::automock;
+
+/// Handle different configuration directory layouts.
+///
+/// At a high level of abstraction, Ricer mainly splits its configuration
+/// directories into two categories: behavior data, and repository data.
+/// The behavior data category houses all files that configure Ricer's
+/// behavior, while the repository data category contains repositories that
+/// Ricer needs to keep track of and manipulate.
+#[cfg_attr(test, automock)]
+pub trait DirLayout {
+    /// Absolute path to directory where configuration files will be stored.
+    fn behavior_dir(&self) -> &Path;
+
+    /// Absolute path to directory where repository data will be stored.
+    fn repo_dir(&self) -> &Path;
+}

--- a/src/manager/locator.rs
+++ b/src/manager/locator.rs
@@ -94,8 +94,7 @@ pub struct XdgDirLayout {
 impl XdgDirLayout {
     pub fn layout() -> Result<Self, LocatorError> {
         trace!("Construct XDG Base Directory Specification layout handler");
-        let layout =
-            ProjectDirs::from("com", "awkless", "ricer").ok_or_else(|| LocatorError::NoWayHome)?;
+        let layout = ProjectDirs::from("com", "awkless", "ricer").ok_or(LocatorError::NoWayHome)?;
         Ok(Self { layout })
     }
 }

--- a/src/manager/locator.rs
+++ b/src/manager/locator.rs
@@ -1,8 +1,14 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: MIT
 
+use directories::ProjectDirs;
+use log::trace;
+use std::path::Path;
+
 #[cfg(test)]
 use mockall::automock;
+
+use crate::manager::LocatorError;
 
 /// Handle different configuration directory layouts.
 ///
@@ -18,4 +24,30 @@ pub trait DirLayout {
 
     /// Absolute path to directory where repository data will be stored.
     fn repo_dir(&self) -> &Path;
+}
+
+/// Configuration directory layout handler following [XDG Base Directory
+/// Specification][xdg].
+///
+/// [xdg]: https://specifications.freedesktop.org/basedir-spec/latest/
+pub struct XdgDirLayout {
+    layout: ProjectDirs,
+}
+
+impl XdgDirLayout {
+    pub fn layout() -> Result<Self, LocatorError> {
+        trace!("Construct XDG Base Directory Specification layout handler");
+        let layout = ProjectDirs::from("com", "awkless", "ricer").ok_or_else(|| LocatorError::NoWayHome)?;
+        Ok(Self { layout })
+    }
+}
+
+impl DirLayout for XdgDirLayout {
+    fn behavior_dir(&self) -> &Path {
+        self.layout.config_dir()
+    }
+
+    fn repo_dir(&self) -> &Path {
+        self.layout.data_dir()
+    }
 }

--- a/src/manager/locator.rs
+++ b/src/manager/locator.rs
@@ -3,7 +3,7 @@
 
 use directories::ProjectDirs;
 use log::{debug, trace};
-use std::path::{PathBuf, Path};
+use std::path::{Path, PathBuf};
 
 #[cfg(test)]
 use mockall::automock;
@@ -39,10 +39,17 @@ impl DefaultDirLocator {
         let hooks_dir = config_dir.join("hooks");
         let repos_dir = layout.repo_dir().join("ricer");
 
-        debug!("Configuration directory located at '{}'", config_dir.display());
+        debug!(
+            "Configuration directory located at '{}'",
+            config_dir.display()
+        );
         debug!("Hook script directory located at '{}'", hooks_dir.display());
         debug!("Repository directory located at '{}'", repos_dir.display());
-        Self { config_dir, hooks_dir, repos_dir }
+        Self {
+            config_dir,
+            hooks_dir,
+            repos_dir,
+        }
     }
 }
 
@@ -87,7 +94,8 @@ pub struct XdgDirLayout {
 impl XdgDirLayout {
     pub fn layout() -> Result<Self, LocatorError> {
         trace!("Construct XDG Base Directory Specification layout handler");
-        let layout = ProjectDirs::from("com", "awkless", "ricer").ok_or_else(|| LocatorError::NoWayHome)?;
+        let layout =
+            ProjectDirs::from("com", "awkless", "ricer").ok_or_else(|| LocatorError::NoWayHome)?;
         Ok(Self { layout })
     }
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
SPDX-License-Identifier: MIT
-->

## Description

Implement configuration data locator API in order to locate important directories that house configuration and repository data for Ricer to manage.

## Area of Effect

- Module `ricer::manager`.
