### PR TITLE
Implement command hook manager

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -17,6 +17,7 @@
 
 use clap::ValueEnum;
 use std::ffi::OsString;
+use std::fmt;
 
 use crate::cli::{Cli, CommandSet, SharedOptions};
 
@@ -51,6 +52,27 @@ impl From<Cli> for Context {
             CommandSet::Rename(_) => Self::Rename(RenameContext::from(opts)),
             CommandSet::Status(_) => Self::Status(StatusContext::from(opts)),
             CommandSet::Git(_) => Self::Git(GitContext::from(opts)),
+        }
+    }
+}
+
+impl fmt::Display for Context {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Context::Bootstrap(_) => write!(f, "bootstrap"),
+            Context::Clone(_) => write!(f, "clone"),
+            Context::Commit(_) => write!(f, "commit"),
+            Context::Delete(_) => write!(f, "delete"),
+            Context::Enter(_) => write!(f, "enter"),
+            Context::Init(_) => write!(f, "init"),
+            Context::List(_) => write!(f, "list"),
+            Context::Pull(_) => write!(f, "pull"),
+            Context::Push(_) => write!(f, "push"),
+            Context::Rename(_) => write!(f, "rename"),
+            Context::Status(_) => write!(f, "status"),
+            Context::Git(_) => {
+                unreachable!("This should not happen. Cannot convert Git context to string")
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ pub mod cli;
 pub mod config;
 pub mod context;
 pub mod manager;
+pub mod wizard;
 
 #[cfg(test)]
 mod tests;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,9 +3,10 @@
 
 use ricer::cli::Cli;
 use ricer::context::Context;
+use ricer::manager::{CommandHookManager, DefaultLocator, HookKind, XdgDirLayout};
 
 use anyhow::Result;
-use log::{error, info, LevelFilter};
+use log::{error, LevelFilter};
 use std::ffi::OsString;
 
 fn main() {
@@ -37,7 +38,11 @@ where
     log::set_max_level(opts.log_opts.log_level_filter());
 
     let ctx = Context::from(opts);
-    info!("{:#?}", ctx);
+    let layout = XdgDirLayout::layout()?;
+    let locator = DefaultLocator::locate(layout);
+    let hook_mgr = CommandHookManager::load(&ctx, &locator)?;
+    hook_mgr.run_hooks(HookKind::Pre)?;
+    hook_mgr.run_hooks(HookKind::Post)?;
 
     Ok(ExitCode::Success)
 }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -16,6 +16,8 @@ pub use locator::*;
 pub use toml::*;
 
 use crate::config::Toml;
+use crate::wizard::PagerPrompt;
+use crate::context::Context;
 
 use log::debug;
 use mkdirp::mkdirp;
@@ -38,10 +40,11 @@ use std::path::Path;
 /// # See also
 ///
 /// - [`Toml`]
-#[derive(Clone, Debug)]
+#[derive(Clone, Default, Debug)]
 pub struct ConfigManager<'cfg, L, T>
 where
     L: Locator,
+    &'cfg L: Default,
     T: TomlManager,
 {
     doc: Toml,
@@ -52,6 +55,7 @@ where
 impl<'cfg, L, T> ConfigManager<'cfg, L, T>
 where
     L: Locator,
+    &'cfg L: Default,
     T: TomlManager,
 {
     /// Load new configuration manager.
@@ -188,9 +192,32 @@ where
 impl<'cfg, L, T> fmt::Display for ConfigManager<'cfg, L, T>
 where
     L: Locator,
+    &'cfg L: Default,
     T: TomlManager,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.doc)
     }
+}
+
+#[derive(Debug)]
+pub struct CommandHookManager<'cfg, L, P>
+where
+    L: Locator,
+    &'cfg L: Default,
+    P: PagerPrompt,
+{
+    context: &'cfg Context,
+    locator: &'cfg L,
+    config: ConfigManager<'cfg, L, CommandHookData>,
+    pager: P,
+}
+
+impl<'cfg, L, P> CommandHookManager<'cfg, L, P>
+where
+    L: Locator,
+    &'cfg L: Default,
+    P: PagerPrompt,
+{
+    // TODO: implement stuffs...
 }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -15,7 +15,7 @@ pub use error::*;
 pub use locator::*;
 pub use toml::*;
 
-use crate::config::{CommandHook, Toml};
+use crate::config::Toml;
 use crate::context::{Context, HookAction};
 use crate::wizard::HookPager;
 
@@ -277,7 +277,7 @@ where
             })?;
 
             if action == &HookAction::Prompt {
-                let workdir = hook.workdir.as_deref().unwrap_or(self.locator.hooks_dir().into());
+                let workdir = hook.workdir.as_deref().unwrap_or(self.locator.hooks_dir());
                 self.pager.page_and_prompt(hook_path.as_path(), workdir, &hook_data)?;
                 if !self.pager.choice() {
                     continue; // Skip this iteration if user denied hook script.

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -16,7 +16,7 @@ pub use locator::*;
 pub use toml::*;
 
 use crate::config::Toml;
-use crate::wizard::PagerPrompt;
+use crate::wizard::HookPager;
 use crate::context::Context;
 
 use log::debug;
@@ -40,11 +40,10 @@ use std::path::Path;
 /// # See also
 ///
 /// - [`Toml`]
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Debug)]
 pub struct ConfigManager<'cfg, L, T>
 where
     L: Locator,
-    &'cfg L: Default,
     T: TomlManager,
 {
     doc: Toml,
@@ -55,7 +54,6 @@ where
 impl<'cfg, L, T> ConfigManager<'cfg, L, T>
 where
     L: Locator,
-    &'cfg L: Default,
     T: TomlManager,
 {
     /// Load new configuration manager.
@@ -192,7 +190,6 @@ where
 impl<'cfg, L, T> fmt::Display for ConfigManager<'cfg, L, T>
 where
     L: Locator,
-    &'cfg L: Default,
     T: TomlManager,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -200,24 +197,22 @@ where
     }
 }
 
-#[derive(Debug)]
-pub struct CommandHookManager<'cfg, L, P>
+pub struct CommandHookManager<'cfg, L>
 where
     L: Locator,
-    &'cfg L: Default,
-    P: PagerPrompt,
 {
     context: &'cfg Context,
     locator: &'cfg L,
     config: ConfigManager<'cfg, L, CommandHookData>,
-    pager: P,
+    pager: HookPager,
 }
 
-impl<'cfg, L, P> CommandHookManager<'cfg, L, P>
+impl<'cfg, L> CommandHookManager<'cfg, L>
 where
     L: Locator,
-    &'cfg L: Default,
-    P: PagerPrompt,
 {
-    // TODO: implement stuffs...
+    pub fn load(context: &'cfg Context, locator: &'cfg L) -> Result<Self, CommandHookManagerError> {
+        let config = ConfigManager::load(CommandHookData, locator)?;
+        Ok(Self { context, locator, config, pager: Default::default() })
+    }
 }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -15,14 +15,15 @@ pub use error::*;
 pub use locator::*;
 pub use toml::*;
 
-use crate::config::Toml;
+use crate::config::{CommandHook, Toml};
+use crate::context::{Context, HookAction};
 use crate::wizard::HookPager;
-use crate::context::Context;
 
-use log::debug;
+use log::{debug, info};
 use mkdirp::mkdirp;
+use run_script::{run_script, ScriptOptions};
 use std::fmt;
-use std::fs::OpenOptions;
+use std::fs::{read_to_string, OpenOptions};
 use std::io::{Read, Write};
 use std::path::Path;
 
@@ -197,6 +198,19 @@ where
     }
 }
 
+/// Command hook execution management.
+///
+/// Executes user-defined hooks according to specified hook actions selected by
+/// the user through [`Context`]. Hooks can be defined as _pre_ or _post_, i.e.,
+/// run _before_ a command, or run _after_ a command. Hooks utilize scripts that
+/// must be defined in the special `hooks/` directory at the top-level of
+/// Ricer's configuration directory.
+///
+/// User can set hook actions to _never_, _always_, and _prompt_. Never action
+/// means that no hook can be executed no questions asked. Always action means
+/// that hooks are executed no questions asked. Finally, prompt action will page
+/// the contents of a hook script for the user to review, and prompt them about
+/// whether or not they want to execute it.
 pub struct CommandHookManager<'cfg, L>
 where
     L: Locator,
@@ -219,4 +233,93 @@ where
     pub fn set_pager(&mut self, pager: HookPager) {
         self.pager = pager;
     }
+
+    /// Run user-defined hooks.
+    ///
+    /// Run specific hook kind for given command that was selected through
+    /// [`Context`].
+    ///
+    /// # Errors
+    ///
+    /// 1. Return [`CommandHookManagerError::GetCmdHook`] if current command
+    ///    hook definition cannot be obtained through hook configuration file.
+    /// 2. Return [`CommandHookManagerError::HookRead`] if hook script cannot
+    ///    be read from `hooks/` directory.
+    /// 3. Return [`CommandHookManagerError::RunHook`] if hook script cannot
+    ///    be executed for whatever reason.
+    /// 4. Return [`CommandHookManagerError::HookPager`] if pager cannot page
+    ///    hook script and prompt user.
+    pub fn run_hooks(&self, hook_kind: HookKind) -> Result<(), CommandHookManagerError> {
+        // INVARIANT: Git command shortcut cannot execute hooks.
+        if matches!(self.context, Context::Git(..)) {
+            return Ok(());
+        }
+
+        let action = self.get_hook_action();
+        if action == &HookAction::Never {
+            return Ok(());
+        }
+
+        let cmd_hook = self.config.get(self.context.to_string())?;
+        for hook in cmd_hook.hooks {
+            let hook_name = match hook_kind {
+                HookKind::Pre => hook.pre.as_ref(),
+                HookKind::Post => hook.post.as_ref(),
+            };
+            let hook_name = match hook_name {
+                Some(name) => name,
+                None => continue, // Skip this iteration if no hook name is found.
+            };
+
+            let hook_path = self.locator.hooks_dir().join(hook_name);
+            let hook_data = read_to_string(&hook_path).map_err(|err| {
+                CommandHookManagerError::HookRead { source: err, path: hook_path.clone() }
+            })?;
+
+            if action == &HookAction::Prompt {
+                let workdir = hook.workdir.as_deref().unwrap_or(self.locator.hooks_dir().into());
+                self.pager.page_and_prompt(hook_path.as_path(), workdir, &hook_data)?;
+                if !self.pager.choice() {
+                    continue; // Skip this iteration if user denied hook script.
+                }
+            }
+
+            let mut hook_opts = ScriptOptions::new();
+            hook_opts.working_directory = hook.workdir;
+            let (code, out, err) = run_script!(hook_data, hook_opts)?;
+            info!("({code}) {}\nstdout: {out}\nstderr: {err}", hook_path.display());
+        }
+
+        Ok(())
+    }
+
+    fn get_hook_action(&self) -> &HookAction {
+        match self.context {
+            Context::Bootstrap(ctx) => &ctx.shared.run_hook,
+            Context::Clone(ctx) => &ctx.shared.run_hook,
+            Context::Commit(ctx) => &ctx.shared.run_hook,
+            Context::Delete(ctx) => &ctx.shared.run_hook,
+            Context::Enter(ctx) => &ctx.shared.run_hook,
+            Context::Init(ctx) => &ctx.shared.run_hook,
+            Context::List(ctx) => &ctx.shared.run_hook,
+            Context::Pull(ctx) => &ctx.shared.run_hook,
+            Context::Push(ctx) => &ctx.shared.run_hook,
+            Context::Rename(ctx) => &ctx.shared.run_hook,
+            Context::Status(ctx) => &ctx.shared.run_hook,
+
+            // INVARIANT: Git command shortcut cannot use hooks.
+            Context::Git(_) => {
+                unreachable!("This should not happen. Git shortcut cannot use hooks")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HookKind {
+    /// Execute hooks _before_ command.
+    Pre,
+
+    /// Execute hooks _after_ command.
+    Post,
 }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -215,4 +215,8 @@ where
         let config = ConfigManager::load(CommandHookData, locator)?;
         Ok(Self { context, locator, config, pager: Default::default() })
     }
+
+    pub fn set_pager(&mut self, pager: HookPager) {
+        self.pager = pager;
+    }
 }

--- a/src/manager/error.rs
+++ b/src/manager/error.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 use crate::config;
+use crate::wizard;
+
 use std::io;
 use std::path::PathBuf;
 
@@ -13,18 +15,60 @@ pub enum LocatorError {
 
 #[derive(Debug, thiserror::Error)]
 pub enum ConfigManagerError {
-    #[error("Failed to make parent directory '{path}' because '{source}'")]
+    #[error("Failed to make parent directory '{path}'")]
     MakeDirP { source: io::Error, path: PathBuf },
 
-    #[error("Failed to open '{path}' because '{source}'")]
+    #[error("Failed to open '{path}'")]
     FileOpen { source: io::Error, path: PathBuf },
 
-    #[error("Failed to read '{path}' because '{source}'")]
+    #[error("Failed to read '{path}'")]
     FileRead { source: io::Error, path: PathBuf },
 
-    #[error("Failed to write '{path}' because '{source}'")]
+    #[error("Failed to write '{path}'")]
     FileWrite { source: io::Error, path: PathBuf },
 
-    #[error("Failed to parse '{path}' because '{source}'")]
+    #[error("Failed to parse '{path}'")]
     Toml { source: config::TomlError, path: PathBuf },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CommandHookManagerError {
+    #[error("Failed to load command hook configuration file")]
+    LoadConfig { source: ConfigManagerError },
+
+    #[error("Failed to get command hook data")]
+    GetCmdHook { source: config::TomlError },
+
+    #[error("Failed to read hook '{path}'")]
+    HookRead { source: io::Error, path: PathBuf },
+
+    #[error("Failed to run hook")]
+    RunHook { source: run_script::ScriptError },
+
+    #[error("Failed to run pager")]
+    HookPager { source: wizard::HookPagerError },
+}
+
+impl From<ConfigManagerError> for CommandHookManagerError {
+    fn from(err: ConfigManagerError) -> Self {
+        CommandHookManagerError::LoadConfig { source: err }
+    }
+}
+
+impl From<config::TomlError> for CommandHookManagerError {
+    fn from(err: config::TomlError) -> Self {
+        CommandHookManagerError::GetCmdHook { source: err }
+    }
+}
+
+impl From<run_script::ScriptError> for CommandHookManagerError {
+    fn from(err: run_script::ScriptError) -> Self {
+        CommandHookManagerError::RunHook { source: err }
+    }
+}
+
+impl From<wizard::HookPagerError> for CommandHookManagerError {
+    fn from(err: wizard::HookPagerError) -> Self {
+        CommandHookManagerError::HookPager { source: err }
+    }
 }

--- a/src/manager/locator.rs
+++ b/src/manager/locator.rs
@@ -32,6 +32,7 @@ pub trait Locator {
     fn repos_config(&self) -> &Path;
 }
 
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct DefaultLocator {
     config_dir: PathBuf,
     hooks_dir: PathBuf,
@@ -43,7 +44,7 @@ pub struct DefaultLocator {
 impl DefaultLocator {
     pub fn locate(layout: impl DirLayout) -> Self {
         trace!("Construct configuration directory locator");
-        let config_dir = layout.config_dir().join("ricer");
+        let config_dir = layout.config_dir().to_path_buf();
         let hooks_dir = config_dir.join("hooks");
         let hooks_config = config_dir.join("hooks.toml");
         let repos_dir = layout.repo_dir().join("ricer");
@@ -52,6 +53,8 @@ impl DefaultLocator {
         debug!("Configuration directory located at '{}'", config_dir.display());
         debug!("Hook script directory located at '{}'", hooks_dir.display());
         debug!("Repository directory located at '{}'", repos_dir.display());
+        debug!("Repository configuration file located at '{}'", repos_config.display());
+        debug!("Hook configuration file located at '{}'", hooks_config.display());
         Self { config_dir, hooks_dir, hooks_config, repos_dir, repos_config }
     }
 }

--- a/src/wizard.rs
+++ b/src/wizard.rs
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: MIT
+
+//! Wizard implementations.
+//!
+//! This module implements helpful wizard functionality to make Ricer's CLI more
+//! user friendly.
+
+use anyhow::Result;
+use std::sync::atomic::{Ordering, AtomicBool};
+use std::sync::Arc;
+use minus::input::{InputEvent, HashedEventRegister};
+use minus::{ExitStrategy, LineNumbers, Pager, page_all};
+
+pub trait PagerPrompt {
+    fn page_and_prompt(&self, file_name: &str, file_data: &str) -> Result<bool>;
+}
+
+#[derive(Debug, Default)]
+pub struct CommandHookPager;
+
+impl PagerPrompt for CommandHookPager {
+    fn page_and_prompt(&self, file_name: &str, file_data: &str) -> Result<bool> {
+        let choice = Arc::new(AtomicBool::default());
+        let mut input = HashedEventRegister::default();
+        let response = choice.clone();
+        input.add_key_events(&["a"], move |_, _| {
+            response.store(true, Ordering::Relaxed);
+            InputEvent::Exit
+        });
+        let response = choice.clone();
+        input.add_key_events(&["d"], move |_, _| {
+            response.store(false, Ordering::Relaxed);
+            InputEvent::Exit
+        });
+
+        let pager = Pager::new();
+        pager.set_prompt(format!("Do you want to execute '{}'? [A]ccept/[D]eny", file_name))?;
+        pager.show_prompt(true)?;
+        pager.set_run_no_overflow(true)?;
+        pager.set_line_numbers(LineNumbers::Enabled)?;
+        pager.push_str(file_data)?;
+        pager.set_input_classifier(Box::new(input))?;
+        pager.set_exit_strategy(ExitStrategy::PagerQuit)?;
+        page_all(pager)?;
+        Ok(choice.load(Ordering::Relaxed))
+    }
+}

--- a/src/wizard.rs
+++ b/src/wizard.rs
@@ -15,38 +15,54 @@ use minus::input::{HashedEventRegister, InputEvent};
 use minus::{page_all, ExitStrategy, LineNumbers, Pager};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::hash::RandomState;
 
-pub trait PagerPrompt {
-    fn page_and_prompt(&self, file_name: &str, file_data: &str) -> Result<bool, HookWizardError>;
+#[cfg(test)]
+use mockall::automock;
+
+#[derive(Default)]
+pub struct HookPager {
+    choice: Arc<AtomicBool>,
 }
 
-#[derive(Debug, Default)]
-pub struct HookWizard;
+#[cfg_attr(test, automock)]
+impl HookPager {
+    pub fn new() -> Self {
+        Self { choice: Arc::new(AtomicBool::default()) }
+    }
 
-impl PagerPrompt for HookWizard {
-    fn page_and_prompt(&self, file_name: &str, file_data: &str) -> Result<bool, HookWizardError> {
-        let choice = Arc::new(AtomicBool::default());
-        let mut input = HashedEventRegister::default();
-        let response = choice.clone();
-        input.add_key_events(&["a"], move |_, _| {
-            response.store(true, Ordering::Relaxed);
-            InputEvent::Exit
-        });
-        let response = choice.clone();
-        input.add_key_events(&["d"], move |_, _| {
-            response.store(false, Ordering::Relaxed);
-            InputEvent::Exit
-        });
+    pub fn choice(&self) -> bool {
+        self.choice.load(Ordering::Relaxed)
+    }
 
+    pub fn page_and_prompt(&self, file_name: &str, file_data: &str) -> Result<(), HookPagerError> {
         let pager = Pager::new();
         pager.set_prompt(format!("Do you want to execute '{}'? [A]ccept/[D]eny", file_name))?;
         pager.show_prompt(true)?;
         pager.set_run_no_overflow(true)?;
         pager.set_line_numbers(LineNumbers::Enabled)?;
         pager.push_str(file_data)?;
-        pager.set_input_classifier(Box::new(input))?;
+        pager.set_input_classifier(self.generate_key_bindings())?;
         pager.set_exit_strategy(ExitStrategy::PagerQuit)?;
         page_all(pager)?;
-        Ok(choice.load(Ordering::Relaxed))
+        Ok(())
+    }
+
+    fn generate_key_bindings(&self) -> Box<HashedEventRegister<RandomState>> {
+        let mut input = HashedEventRegister::default();
+
+        let response = self.choice.clone();
+        input.add_key_events(&["a"], move |_, _| {
+            response.store(true, Ordering::Relaxed);
+            InputEvent::Exit
+        });
+
+        let response = self.choice.clone();
+        input.add_key_events(&["d"], move |_, _| {
+            response.store(false, Ordering::Relaxed);
+            InputEvent::Exit
+        });
+
+        Box::new(input)
     }
 }

--- a/src/wizard.rs
+++ b/src/wizard.rs
@@ -13,9 +13,10 @@ pub use error::*;
 
 use minus::input::{HashedEventRegister, InputEvent};
 use minus::{page_all, ExitStrategy, LineNumbers, Pager};
+use std::hash::RandomState;
+use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::hash::RandomState;
 
 #[cfg(test)]
 use mockall::automock;
@@ -35,9 +36,18 @@ impl HookPager {
         self.choice.load(Ordering::Relaxed)
     }
 
-    pub fn page_and_prompt(&self, file_name: &str, file_data: &str) -> Result<(), HookPagerError> {
+    pub fn page_and_prompt(
+        &self,
+        file_name: &Path,
+        workdir: &Path,
+        file_data: &str,
+    ) -> Result<(), HookPagerError> {
         let pager = Pager::new();
-        pager.set_prompt(format!("Do you want to execute '{}'? [A]ccept/[D]eny", file_name))?;
+        pager.set_prompt(format!(
+            "Run '{}' at '{}'? [a]ccept/[d]eny",
+            file_name.display(),
+            workdir.display(),
+        ))?;
         pager.show_prompt(true)?;
         pager.set_run_no_overflow(true)?;
         pager.set_line_numbers(LineNumbers::Enabled)?;

--- a/src/wizard.rs
+++ b/src/wizard.rs
@@ -6,21 +6,25 @@
 //! This module implements helpful wizard functionality to make Ricer's CLI more
 //! user friendly.
 
-use anyhow::Result;
-use std::sync::atomic::{Ordering, AtomicBool};
+mod error;
+
+#[doc(inline)]
+pub use error::*;
+
+use minus::input::{HashedEventRegister, InputEvent};
+use minus::{page_all, ExitStrategy, LineNumbers, Pager};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use minus::input::{InputEvent, HashedEventRegister};
-use minus::{ExitStrategy, LineNumbers, Pager, page_all};
 
 pub trait PagerPrompt {
-    fn page_and_prompt(&self, file_name: &str, file_data: &str) -> Result<bool>;
+    fn page_and_prompt(&self, file_name: &str, file_data: &str) -> Result<bool, HookWizardError>;
 }
 
 #[derive(Debug, Default)]
-pub struct CommandHookPager;
+pub struct HookWizard;
 
-impl PagerPrompt for CommandHookPager {
-    fn page_and_prompt(&self, file_name: &str, file_data: &str) -> Result<bool> {
+impl PagerPrompt for HookWizard {
+    fn page_and_prompt(&self, file_name: &str, file_data: &str) -> Result<bool, HookWizardError> {
         let choice = Arc::new(AtomicBool::default());
         let mut input = HashedEventRegister::default();
         let response = choice.clone();

--- a/src/wizard/error.rs
+++ b/src/wizard/error.rs
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: MIT
+
+use minus::error;
+
+#[derive(Debug, thiserror::Error)]
+pub enum HookWizardError {
+    #[error("Minus pager failed because '{source}'")]
+    Minus { source: error::MinusError }
+}
+
+impl From<error::MinusError> for  HookWizardError {
+    fn from(err: error::MinusError) -> Self {
+        HookWizardError::Minus { source: err }
+    }
+}

--- a/src/wizard/error.rs
+++ b/src/wizard/error.rs
@@ -4,13 +4,13 @@
 use minus::error;
 
 #[derive(Debug, thiserror::Error)]
-pub enum HookWizardError {
+pub enum HookPagerError {
     #[error("Minus pager failed because '{source}'")]
     Minus { source: error::MinusError },
 }
 
-impl From<error::MinusError> for HookWizardError {
+impl From<error::MinusError> for HookPagerError {
     fn from(err: error::MinusError) -> Self {
-        HookWizardError::Minus { source: err }
+        HookPagerError::Minus { source: err }
     }
 }

--- a/src/wizard/error.rs
+++ b/src/wizard/error.rs
@@ -6,10 +6,10 @@ use minus::error;
 #[derive(Debug, thiserror::Error)]
 pub enum HookWizardError {
     #[error("Minus pager failed because '{source}'")]
-    Minus { source: error::MinusError }
+    Minus { source: error::MinusError },
 }
 
-impl From<error::MinusError> for  HookWizardError {
+impl From<error::MinusError> for HookWizardError {
     fn from(err: error::MinusError) -> Self {
         HookWizardError::Minus { source: err }
     }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
SPDX-License-Identifier: MIT
-->

## Description

Implement command hook manager code so Ricer can handle user defined hook scripts defined in the `$XDG_CONFIG_HOME/ricer/hooks.toml` file.

## Area of Effect

- Module `ricer::wizard`.
- Module `ricer::manager`.
