### PR TITLE
Simplify `ricer::manager::Locator` API

### DIFF
--- a/src/config/entry.rs
+++ b/src/config/entry.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use toml_edit::visit::{visit_inline_table, visit_table_like_kv, Visit};
 use toml_edit::{Array, InlineTable, Item, Key, Table, Value};
 
-pub trait Entry: cmp::PartialEq + fmt::Debug + From<(Key, Item)> {
+pub trait ConfigEntry: cmp::PartialEq + fmt::Debug + From<(Key, Item)> {
     fn to_toml(&self) -> (Key, Item);
 }
 
@@ -66,7 +66,7 @@ impl Repository {
     }
 }
 
-impl Entry for Repository {
+impl ConfigEntry for Repository {
     fn to_toml(&self) -> (Key, Item) {
         let mut repo = Table::new();
         let mut repo_bootstrap = Table::new();
@@ -301,7 +301,7 @@ impl CommandHook {
     }
 }
 
-impl Entry for CommandHook {
+impl ConfigEntry for CommandHook {
     fn to_toml(&self) -> (Key, Item) {
         let mut tables = Array::new();
         let mut iter = self.hooks.iter().enumerate().peekable();

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -8,12 +8,14 @@
 
 mod error;
 mod locator;
+mod toml;
 
 #[doc(inline)]
 pub use error::*;
 pub use locator::*;
+pub use toml::*;
 
-use crate::config::{CommandHook, ConfigEntry, Repository, Toml, TomlError};
+use crate::config::Toml;
 
 use log::debug;
 use mkdirp::mkdirp;
@@ -190,112 +192,5 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.doc)
-    }
-}
-
-/// TOML serialization and deserialization manager.
-///
-/// Interface to simplify serialization and deserialization of parsed TOML data.
-///
-/// # See also
-///
-/// - [`Toml`]
-pub trait TomlManager: fmt::Debug {
-    type Entry: ConfigEntry;
-
-    fn get(&self, doc: &Toml, key: &str) -> Result<Self::Entry, TomlError>;
-    fn add(&self, doc: &mut Toml, entry: Self::Entry) -> Result<Option<Self::Entry>, TomlError>;
-    fn remove(&self, doc: &mut Toml, key: &str) -> Result<Self::Entry, TomlError>;
-    fn rename(&self, doc: &mut Toml, from: &str, to: &str) -> Result<Self::Entry, TomlError>;
-    fn location<'cfg>(&self, locator: &'cfg impl Locator) -> &'cfg Path;
-}
-
-/// Repository data configuration management.
-///
-/// Handles serialization and deserialization of repository settings.
-/// Repository settings are held within the "repos" section of a
-/// configuration file.
-///
-/// # Invariants
-///
-/// Will preserve existing formatting of configuration file if any.
-///
-/// # See also
-///
-/// - [`Toml`]
-/// - [`Repository`]
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct RepositoryData;
-
-impl TomlManager for RepositoryData {
-    type Entry = Repository;
-
-    fn get(&self, doc: &Toml, key: &str) -> Result<Self::Entry, TomlError> {
-        let entry = doc.get("repos", key.as_ref())?;
-        Ok(Repository::from(entry))
-    }
-
-    fn add(&self, doc: &mut Toml, entry: Self::Entry) -> Result<Option<Self::Entry>, TomlError> {
-        let entry = doc.add("repos", entry.to_toml())?.map(Repository::from);
-        Ok(entry)
-    }
-
-    fn remove(&self, doc: &mut Toml, key: &str) -> Result<Self::Entry, TomlError> {
-        let entry = doc.remove("repos", key.as_ref())?;
-        Ok(Repository::from(entry))
-    }
-
-    fn rename(&self, doc: &mut Toml, from: &str, to: &str) -> Result<Self::Entry, TomlError> {
-        let entry = doc.rename("repos", from.as_ref(), to.as_ref())?;
-        Ok(Repository::from(entry))
-    }
-
-    fn location<'cfg>(&self, locator: &'cfg impl Locator) -> &'cfg Path {
-        locator.repos_config()
-    }
-}
-
-/// Command hook configuration management.
-///
-/// Handles serialization and deserialization of command hook settings.
-/// Command hook settings are held within the "hooks" section of a
-/// configuration file.
-///
-/// # Invariants
-///
-/// Will preserve existing formatting of configuration file if any.
-///
-/// # See also
-///
-/// - [`Toml`]
-/// - [`CommandHook`]
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct CommandHookData;
-
-impl TomlManager for CommandHookData {
-    type Entry = CommandHook;
-
-    fn get(&self, doc: &Toml, key: &str) -> Result<Self::Entry, TomlError> {
-        let entry = doc.get("hooks", key.as_ref())?;
-        Ok(CommandHook::from(entry))
-    }
-
-    fn add(&self, doc: &mut Toml, entry: Self::Entry) -> Result<Option<Self::Entry>, TomlError> {
-        let entry = doc.add("hooks", entry.to_toml())?.map(CommandHook::from);
-        Ok(entry)
-    }
-
-    fn remove(&self, doc: &mut Toml, key: &str) -> Result<Self::Entry, TomlError> {
-        let entry = doc.remove("hooks", key.as_ref())?;
-        Ok(CommandHook::from(entry))
-    }
-
-    fn rename(&self, doc: &mut Toml, from: &str, to: &str) -> Result<Self::Entry, TomlError> {
-        let entry = doc.rename("hooks", from.as_ref(), to.as_ref())?;
-        Ok(CommandHook::from(entry))
-    }
-
-    fn location<'cfg>(&self, locator: &'cfg impl Locator) -> &'cfg Path {
-        locator.hooks_config()
     }
 }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -117,10 +117,15 @@ where
             .create(true)
             .truncate(false)
             .open(self.as_path())
-            .map_err(|err| ConfigManagerError::FileOpen { source: err, path: self.as_path().into() })?;
+            .map_err(|err| ConfigManagerError::FileOpen {
+                source: err,
+                path: self.as_path().into(),
+            })?;
         let buffer = self.doc.to_string();
-        file.write_all(buffer.as_bytes())
-            .map_err(|err| ConfigManagerError::FileWrite { source: err, path: self.as_path().into() })?;
+        file.write_all(buffer.as_bytes()).map_err(|err| ConfigManagerError::FileWrite {
+            source: err,
+            path: self.as_path().into(),
+        })?;
 
         Ok(())
     }
@@ -141,10 +146,7 @@ where
     /// # Errors
     ///
     /// 1. Return [`ConfigManagerError::Toml`] if entry cannot be serialized.
-    pub fn add(
-        &mut self,
-        entry: T::Entry,
-    ) -> Result<Option<T::Entry>, ConfigManagerError> {
+    pub fn add(&mut self, entry: T::Entry) -> Result<Option<T::Entry>, ConfigManagerError> {
         self.config
             .add(&mut self.doc, entry)
             .map_err(|err| ConfigManagerError::Toml { source: err, path: self.as_path().into() })
@@ -205,7 +207,7 @@ pub trait TomlManager: fmt::Debug {
     fn add(&self, doc: &mut Toml, entry: Self::Entry) -> Result<Option<Self::Entry>, TomlError>;
     fn remove(&self, doc: &mut Toml, key: &str) -> Result<Self::Entry, TomlError>;
     fn rename(&self, doc: &mut Toml, from: &str, to: &str) -> Result<Self::Entry, TomlError>;
-    fn location<'path>(&self, locator: &'path impl Locator) -> &'path Path;
+    fn location<'cfg>(&self, locator: &'cfg impl Locator) -> &'cfg Path;
 }
 
 /// Repository data configuration management.
@@ -233,11 +235,7 @@ impl TomlManager for RepositoryData {
         Ok(Repository::from(entry))
     }
 
-    fn add(
-        &self,
-        doc: &mut Toml,
-        entry: Self::Entry,
-    ) -> Result<Option<Self::Entry>, TomlError> {
+    fn add(&self, doc: &mut Toml, entry: Self::Entry) -> Result<Option<Self::Entry>, TomlError> {
         let entry = doc.add("repos", entry.to_toml())?.map(Repository::from);
         Ok(entry)
     }
@@ -252,7 +250,7 @@ impl TomlManager for RepositoryData {
         Ok(Repository::from(entry))
     }
 
-    fn location<'path>(&self, locator: &'path impl Locator) -> &'path Path {
+    fn location<'cfg>(&self, locator: &'cfg impl Locator) -> &'cfg Path {
         locator.repos_config()
     }
 }
@@ -282,11 +280,7 @@ impl TomlManager for CommandHookData {
         Ok(CommandHook::from(entry))
     }
 
-    fn add(
-        &self,
-        doc: &mut Toml,
-        entry: Self::Entry,
-    ) -> Result<Option<Self::Entry>, TomlError> {
+    fn add(&self, doc: &mut Toml, entry: Self::Entry) -> Result<Option<Self::Entry>, TomlError> {
         let entry = doc.add("hooks", entry.to_toml())?.map(CommandHook::from);
         Ok(entry)
     }
@@ -301,7 +295,7 @@ impl TomlManager for CommandHookData {
         Ok(CommandHook::from(entry))
     }
 
-    fn location<'path>(&self, locator: &'path impl Locator) -> &'path Path {
+    fn location<'cfg>(&self, locator: &'cfg impl Locator) -> &'cfg Path {
         locator.hooks_config()
     }
 }

--- a/src/manager/locator.rs
+++ b/src/manager/locator.rs
@@ -15,38 +15,48 @@ use mockall::automock;
 /// Locates absolute paths to the three special directories that Ricer
 /// relies on.
 #[cfg_attr(test, automock)]
-pub trait DirLocator {
+pub trait Locator {
     /// Expected absolute path to configuration file directory.
     fn config_dir(&self) -> &Path;
 
     /// Expected absolute path to hook script directory.
     fn hooks_dir(&self) -> &Path;
 
+    /// Expected absolute path to command hook configuration file.
+    fn hooks_config(&self) -> &Path;
+
     /// Expected absolute path to repository directory.
     fn repos_dir(&self) -> &Path;
+
+    /// Expected absolute path to repository configuration file.
+    fn repos_config(&self) -> &Path;
 }
 
-pub struct DefaultDirLocator {
+pub struct DefaultLocator {
     config_dir: PathBuf,
     hooks_dir: PathBuf,
+    hooks_config: PathBuf,
     repos_dir: PathBuf,
+    repos_config: PathBuf,
 }
 
-impl DefaultDirLocator {
+impl DefaultLocator {
     pub fn locate(layout: impl DirLayout) -> Self {
         trace!("Construct configuration directory locator");
         let config_dir = layout.config_dir().join("ricer");
         let hooks_dir = config_dir.join("hooks");
+        let hooks_config = config_dir.join("hooks.toml");
         let repos_dir = layout.repo_dir().join("ricer");
+        let repos_config = config_dir.join("repos.toml");
 
         debug!("Configuration directory located at '{}'", config_dir.display());
         debug!("Hook script directory located at '{}'", hooks_dir.display());
         debug!("Repository directory located at '{}'", repos_dir.display());
-        Self { config_dir, hooks_dir, repos_dir }
+        Self { config_dir, hooks_dir, hooks_config, repos_dir, repos_config }
     }
 }
 
-impl DirLocator for DefaultDirLocator {
+impl Locator for DefaultLocator {
     fn config_dir(&self) -> &Path {
         self.config_dir.as_path()
     }
@@ -55,8 +65,16 @@ impl DirLocator for DefaultDirLocator {
         self.hooks_dir.as_path()
     }
 
+    fn hooks_config(&self) -> &Path {
+        self.hooks_config.as_path()
+    }
+
     fn repos_dir(&self) -> &Path {
         self.repos_dir.as_path()
+    }
+
+    fn repos_config(&self) -> &Path {
+        self.repos_config.as_path()
     }
 }
 

--- a/src/manager/toml.rs
+++ b/src/manager/toml.rs
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: MIT
+
+use crate::config::{CommandHook, ConfigEntry, Repository, Toml, TomlError};
+use crate::manager::Locator;
+
+use std::fmt;
+use std::path::Path;
+
+/// TOML serialization and deserialization manager.
+///
+/// Interface to simplify serialization and deserialization of parsed TOML data.
+///
+/// # See also
+///
+/// - [`Toml`]
+pub trait TomlManager: fmt::Debug {
+    type Entry: ConfigEntry;
+
+    fn get(&self, doc: &Toml, key: &str) -> Result<Self::Entry, TomlError>;
+    fn add(&self, doc: &mut Toml, entry: Self::Entry) -> Result<Option<Self::Entry>, TomlError>;
+    fn remove(&self, doc: &mut Toml, key: &str) -> Result<Self::Entry, TomlError>;
+    fn rename(&self, doc: &mut Toml, from: &str, to: &str) -> Result<Self::Entry, TomlError>;
+    fn location<'cfg>(&self, locator: &'cfg impl Locator) -> &'cfg Path;
+}
+
+/// Repository data configuration management.
+///
+/// Handles serialization and deserialization of repository settings.
+/// Repository settings are held within the "repos" section of a
+/// configuration file.
+///
+/// # Invariants
+///
+/// Will preserve existing formatting of configuration file if any.
+///
+/// # See also
+///
+/// - [`Toml`]
+/// - [`Repository`]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RepositoryData;
+
+impl TomlManager for RepositoryData {
+    type Entry = Repository;
+
+    fn get(&self, doc: &Toml, key: &str) -> Result<Self::Entry, TomlError> {
+        let entry = doc.get("repos", key.as_ref())?;
+        Ok(Repository::from(entry))
+    }
+
+    fn add(&self, doc: &mut Toml, entry: Self::Entry) -> Result<Option<Self::Entry>, TomlError> {
+        let entry = doc.add("repos", entry.to_toml())?.map(Repository::from);
+        Ok(entry)
+    }
+
+    fn remove(&self, doc: &mut Toml, key: &str) -> Result<Self::Entry, TomlError> {
+        let entry = doc.remove("repos", key.as_ref())?;
+        Ok(Repository::from(entry))
+    }
+
+    fn rename(&self, doc: &mut Toml, from: &str, to: &str) -> Result<Self::Entry, TomlError> {
+        let entry = doc.rename("repos", from.as_ref(), to.as_ref())?;
+        Ok(Repository::from(entry))
+    }
+
+    fn location<'cfg>(&self, locator: &'cfg impl Locator) -> &'cfg Path {
+        locator.repos_config()
+    }
+}
+
+/// Command hook configuration management.
+///
+/// Handles serialization and deserialization of command hook settings.
+/// Command hook settings are held within the "hooks" section of a
+/// configuration file.
+///
+/// # Invariants
+///
+/// Will preserve existing formatting of configuration file if any.
+///
+/// # See also
+///
+/// - [`Toml`]
+/// - [`CommandHook`]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CommandHookData;
+
+impl TomlManager for CommandHookData {
+    type Entry = CommandHook;
+
+    fn get(&self, doc: &Toml, key: &str) -> Result<Self::Entry, TomlError> {
+        let entry = doc.get("hooks", key.as_ref())?;
+        Ok(CommandHook::from(entry))
+    }
+
+    fn add(&self, doc: &mut Toml, entry: Self::Entry) -> Result<Option<Self::Entry>, TomlError> {
+        let entry = doc.add("hooks", entry.to_toml())?.map(CommandHook::from);
+        Ok(entry)
+    }
+
+    fn remove(&self, doc: &mut Toml, key: &str) -> Result<Self::Entry, TomlError> {
+        let entry = doc.remove("hooks", key.as_ref())?;
+        Ok(CommandHook::from(entry))
+    }
+
+    fn rename(&self, doc: &mut Toml, from: &str, to: &str) -> Result<Self::Entry, TomlError> {
+        let entry = doc.rename("hooks", from.as_ref(), to.as_ref())?;
+        Ok(CommandHook::from(entry))
+    }
+
+    fn location<'cfg>(&self, locator: &'cfg impl Locator) -> &'cfg Path {
+        locator.hooks_config()
+    }
+}

--- a/src/tests/config/hook.rs
+++ b/src/tests/config/hook.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: MIT
 
-use crate::config::{CommandHook, Entry, Hook};
+use crate::config::{CommandHook, ConfigEntry, Hook};
 
 use anyhow::Result;
 use indoc::indoc;

--- a/src/tests/config/repository.rs
+++ b/src/tests/config/repository.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: MIT
 
-use crate::config::{Bootstrap, Entry, OsType, Repository};
+use crate::config::{Bootstrap, ConfigEntry, OsType, Repository};
 
 use anyhow::Result;
 use indoc::indoc;


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
SPDX-License-Identifier: MIT
-->

## Description

This pull request moves locating configuration files from `TomlManager` to `Locator`, because `Locator` is supposed to do this by default.

## Area of Effect

- Module `ricer::config`.
- Module `ricer::manager`.
