### PR TITLE
Move locator logic out of `manager` module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@
 pub mod cli;
 pub mod config;
 pub mod context;
+pub mod locate;
 pub mod manager;
 pub mod wizard;
 

--- a/src/locate/error.rs
+++ b/src/locate/error.rs
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: MIT
+
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+pub enum LocateError {
+    #[error("Cannot determine path to home directory")]
+    NoWayHome,
+}

--- a/src/locate/layout.rs
+++ b/src/locate/layout.rs
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: MIT
+
+use crate::locate::LocateError;
+
+use directories::ProjectDirs;
+use log::trace;
+use std::path::Path;
+
+#[cfg(test)]
+use mockall::automock;
+
+/// Specify expected configuration directory layout.
+#[cfg_attr(test, automock)]
+pub trait DirLayout {
+    /// Absolute path to directory where configuration files will be stored.
+    fn config_dir(&self) -> &Path;
+
+    /// Absolute path to directory where repository data will be stored.
+    fn repo_dir(&self) -> &Path;
+}
+
+/// Configuration directory layout handler following [XDG Base Directory
+/// Specification][xdg].
+///
+/// # Invariants
+///
+/// 1. Caller must validate paths themselves.
+///
+/// [xdg]: https://specifications.freedesktop.org/basedir-spec/latest/
+pub struct XdgDirLayout {
+    layout: ProjectDirs,
+}
+
+impl XdgDirLayout {
+    pub fn layout() -> Result<Self, LocateError> {
+        trace!("Construct XDG Base Directory Specification layout handler");
+        let layout = ProjectDirs::from("com", "awkless", "ricer").ok_or(LocateError::NoWayHome)?;
+        Ok(Self { layout })
+    }
+}
+
+impl DirLayout for XdgDirLayout {
+    fn config_dir(&self) -> &Path {
+        self.layout.config_dir()
+    }
+
+    fn repo_dir(&self) -> &Path {
+        self.layout.data_dir()
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,8 @@
 
 use ricer::cli::Cli;
 use ricer::context::Context;
-use ricer::manager::{CommandHookManager, DefaultLocator, HookKind, XdgDirLayout};
+use ricer::locate::{DefaultLocator, XdgDirLayout};
+use ricer::manager::{CommandHookManager, HookKind};
 
 use anyhow::Result;
 use log::{error, LevelFilter};

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -7,16 +7,15 @@
 //! manage configuration, hook, and repository data provided by the user.
 
 mod error;
-mod locator;
 mod toml;
 
 #[doc(inline)]
 pub use error::*;
-pub use locator::*;
 pub use toml::*;
 
 use crate::config::Toml;
 use crate::context::{Context, HookAction};
+use crate::locate::Locator;
 use crate::wizard::HookPager;
 
 use log::{debug, info};

--- a/src/manager/error.rs
+++ b/src/manager/error.rs
@@ -7,12 +7,6 @@ use crate::wizard;
 use std::io;
 use std::path::PathBuf;
 
-#[derive(Debug, PartialEq, Eq, thiserror::Error)]
-pub enum LocatorError {
-    #[error("Cannot determine path to home directory")]
-    NoWayHome,
-}
-
 #[derive(Debug, thiserror::Error)]
 pub enum ConfigManagerError {
     #[error("Failed to make parent directory '{path}'")]

--- a/src/tests/manager.rs
+++ b/src/tests/manager.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 use crate::config::{CommandHook, ConfigEntry, Hook, Repository};
+use crate::locate::MockLocator;
 use crate::manager::{
-    CommandHookData, ConfigManager, ConfigManagerError, MockLocator, RepositoryData, TomlManager,
+    CommandHookData, ConfigManager, ConfigManagerError, RepositoryData, TomlManager,
 };
 use crate::tests::FakeConfigDir;
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
SPDX-License-Identifier: MIT
-->

## Description

Move private sub-module `ricer::manager::locator` out as a public top-level module named `ricer::locate`. This refactor is apart of a larger effort to further simplify the `ricer::manager` module in order to prevent it from becoming a god module.

## Area of Effect

- Module `ricer::locate`
- Module `ricer::manager`
- Module `ricer::tests`
- Binary.
