### PR TITLE
Implement `ricer::vcs::GitRepo`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -354,7 +354,7 @@ impl Config for CmdHookConfig {
 mod tests {
     use super::*;
     use crate::locate::MockLocator;
-    use crate::testenv::{FixtureHarness, FixtureKind};
+    use crate::testenv::{FixtureHarness, FileKind};
 
     use anyhow::Result;
     use indoc::indoc;
@@ -364,37 +364,34 @@ mod tests {
     #[fixture]
     fn config_dir() -> Result<FixtureHarness> {
         let harness = FixtureHarness::open()?
-            .with_file_set(|clump| {
-                clump
-                    .with_fixture("config.toml", |fixture| {
-                        fixture
-                            .with_data(indoc! {r#"
-                                # Formatting should remain the same!
+            .with_fixture("config.toml", |fixture| {
+                fixture
+                    .with_data(indoc! {r#"
+                        # Formatting should remain the same!
 
-                                [repos.vim]
-                                branch = "master"
-                                remote = "origin"
-                                workdir_home = true
+                        [repos.vim]
+                        branch = "master"
+                        remote = "origin"
+                        workdir_home = true
 
-                                [hooks]
-                                bootstrap = [
-                                    { pre = "hook.sh", post = "hook.sh", workdir = "/some/dir" },
-                                    { pre = "hook.sh" }
-                                ]
-                            "#})
-                            .with_kind(FixtureKind::NormalFile)
-                    })
-                    .with_fixture("not_table.toml", |fixture| {
-                        fixture
-                            .with_data(indoc! {r#"
-                                repos = 'not a table'
-                                hooks = 'not a table'
-                            "#})
-                            .with_kind(FixtureKind::NormalFile)
-                    })
-                    .with_fixture("bad_format.toml", |fixture| {
-                        fixture.with_data("this 'will fail!").with_kind(FixtureKind::NormalFile)
-                    })
+                        [hooks]
+                        bootstrap = [
+                            { pre = "hook.sh", post = "hook.sh", workdir = "/some/dir" },
+                            { pre = "hook.sh" }
+                        ]
+                    "#})
+                    .with_kind(FileKind::Normal)
+            })
+            .with_fixture("not_table.toml", |fixture| {
+                fixture
+                    .with_data(indoc! {r#"
+                        repos = 'not a table'
+                        hooks = 'not a table'
+                    "#})
+                    .with_kind(FileKind::Normal)
+            })
+            .with_fixture("bad_format.toml", |fixture| {
+                fixture.with_data("this 'will fail!").with_kind(FileKind::Normal)
             })
             .setup()?;
         Ok(harness)

--- a/src/config.rs
+++ b/src/config.rs
@@ -355,7 +355,7 @@ mod tests {
     use super::*;
     use crate::{
         locate::MockLocator,
-        testenv::{FixtureHarness, FileKind},
+        testenv::{FileKind, FixtureHarness},
     };
 
     use anyhow::Result;

--- a/src/config.rs
+++ b/src/config.rs
@@ -395,7 +395,7 @@ mod tests {
                 FixtureKind::NormalFile,
             )
             .with_file("bad_format.toml", "this 'will fail!", FixtureKind::NormalFile)
-            .write()?;
+            .setup()?;
         Ok(dir)
     }
 
@@ -407,7 +407,7 @@ mod tests {
         #[case] config_kind: impl Config,
     ) -> Result<()> {
         let config_dir = config_dir?;
-        let fixture = config_dir.get_fixture("config.toml")?;
+        let fixture = config_dir.fixture("config.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_repos_config().return_const(fixture.as_path().into());
         locator.expect_hooks_config().return_const(fixture.as_path().into());
@@ -444,7 +444,7 @@ mod tests {
         #[case] config_kind: impl Config,
     ) -> Result<()> {
         let config_dir = config_dir?;
-        let fixture = config_dir.get_fixture("bad_format.toml")?;
+        let fixture = config_dir.fixture("bad_format.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_repos_config().return_const(fixture.as_path().into());
         locator.expect_hooks_config().return_const(fixture.as_path().into());
@@ -474,7 +474,7 @@ mod tests {
         T: Config<Entry = E>,
     {
         let mut config_dir = config_dir?;
-        let fixture = config_dir.get_fixture_mut("config.toml")?;
+        let fixture = config_dir.fixture_mut("config.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_repos_config().return_const(fixture.as_path().into());
         locator.expect_hooks_config().return_const(fixture.as_path().into());
@@ -531,7 +531,7 @@ mod tests {
         T: Config<Entry = E>,
     {
         let config_dir = config_dir?;
-        let fixture = config_dir.get_fixture("config.toml")?;
+        let fixture = config_dir.fixture("config.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_repos_config().return_const(fixture.as_path().into());
         locator.expect_hooks_config().return_const(fixture.as_path().into());
@@ -551,7 +551,7 @@ mod tests {
         #[case] config_kind: impl Config,
     ) -> Result<()> {
         let config_dir = config_dir?;
-        let fixture = config_dir.get_fixture("config.toml")?;
+        let fixture = config_dir.fixture("config.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_repos_config().return_const(fixture.as_path().into());
         locator.expect_hooks_config().return_const(fixture.as_path().into());
@@ -582,7 +582,7 @@ mod tests {
         T: Config<Entry = E>,
     {
         let mut config_dir = config_dir?;
-        let fixture = config_dir.get_fixture_mut("config.toml")?;
+        let fixture = config_dir.fixture_mut("config.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_repos_config().return_const(fixture.as_path().into());
         locator.expect_hooks_config().return_const(fixture.as_path().into());
@@ -623,7 +623,7 @@ mod tests {
         T: Config<Entry = E>,
     {
         let mut config_dir = config_dir?;
-        let fixture = config_dir.get_fixture_mut("config.toml")?;
+        let fixture = config_dir.fixture_mut("config.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_repos_config().return_const(fixture.as_path().into());
         locator.expect_hooks_config().return_const(fixture.as_path().into());
@@ -646,7 +646,7 @@ mod tests {
         #[case] config_kind: impl Config,
     ) -> Result<()> {
         let mut config_dir = config_dir?;
-        let fixture = config_dir.get_fixture_mut("not_table.toml")?;
+        let fixture = config_dir.fixture_mut("not_table.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_repos_config().return_const(fixture.as_path().into());
         locator.expect_hooks_config().return_const(fixture.as_path().into());
@@ -684,7 +684,7 @@ mod tests {
         T: Config<Entry = E>,
     {
         let mut config_dir = config_dir?;
-        let fixture = config_dir.get_fixture_mut("config.toml")?;
+        let fixture = config_dir.fixture_mut("config.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_repos_config().return_const(fixture.as_path().into());
         locator.expect_hooks_config().return_const(fixture.as_path().into());
@@ -707,7 +707,7 @@ mod tests {
         #[case] config_kind: impl Config,
     ) -> Result<()> {
         let config_dir = config_dir?;
-        let fixture = config_dir.get_fixture("not_table.toml")?;
+        let fixture = config_dir.fixture("not_table.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_repos_config().return_const(fixture.as_path().into());
         locator.expect_hooks_config().return_const(fixture.as_path().into());
@@ -743,7 +743,7 @@ mod tests {
         T: Config<Entry = E>,
     {
         let mut config_dir = config_dir?;
-        let fixture = config_dir.get_fixture_mut("config.toml")?;
+        let fixture = config_dir.fixture_mut("config.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_repos_config().return_const(fixture.as_path().into());
         locator.expect_hooks_config().return_const(fixture.as_path().into());
@@ -766,7 +766,7 @@ mod tests {
         #[case] config_kind: impl Config,
     ) -> Result<()> {
         let config_dir = config_dir?;
-        let fixture = config_dir.get_fixture("not_table.toml")?;
+        let fixture = config_dir.fixture("not_table.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_repos_config().return_const(fixture.as_path().into());
         locator.expect_hooks_config().return_const(fixture.as_path().into());

--- a/src/config.rs
+++ b/src/config.rs
@@ -353,8 +353,10 @@ impl Config for CmdHookConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::locate::MockLocator;
-    use crate::testenv::{FixtureHarness, FileKind};
+    use crate::{
+        locate::MockLocator,
+        testenv::{FixtureHarness, FileKind},
+    };
 
     use anyhow::Result;
     use indoc::indoc;
@@ -364,7 +366,7 @@ mod tests {
     #[fixture]
     fn config_dir() -> Result<FixtureHarness> {
         let harness = FixtureHarness::open()?
-            .with_fixture("config.toml", |fixture| {
+            .with_file("config.toml", |fixture| {
                 fixture
                     .with_data(indoc! {r#"
                         # Formatting should remain the same!
@@ -382,7 +384,7 @@ mod tests {
                     "#})
                     .with_kind(FileKind::Normal)
             })
-            .with_fixture("not_table.toml", |fixture| {
+            .with_file("not_table.toml", |fixture| {
                 fixture
                     .with_data(indoc! {r#"
                         repos = 'not a table'
@@ -390,7 +392,7 @@ mod tests {
                     "#})
                     .with_kind(FileKind::Normal)
             })
-            .with_fixture("bad_format.toml", |fixture| {
+            .with_file("bad_format.toml", |fixture| {
                 fixture.with_data("this 'will fail!").with_kind(FileKind::Normal)
             })
             .setup()?;
@@ -405,7 +407,7 @@ mod tests {
         #[case] config_kind: impl Config,
     ) -> Result<()> {
         let config_dir = config_dir?;
-        let fixture = config_dir.get_fixture("config.toml")?;
+        let fixture = config_dir.get_file("config.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_repos_config().return_const(fixture.as_path().into());
         locator.expect_hooks_config().return_const(fixture.as_path().into());
@@ -442,7 +444,7 @@ mod tests {
         #[case] config_kind: impl Config,
     ) -> Result<()> {
         let config_dir = config_dir?;
-        let fixture = config_dir.get_fixture("bad_format.toml")?;
+        let fixture = config_dir.get_file("bad_format.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_repos_config().return_const(fixture.as_path().into());
         locator.expect_hooks_config().return_const(fixture.as_path().into());
@@ -472,7 +474,7 @@ mod tests {
         T: Config<Entry = E>,
     {
         let mut config_dir = config_dir?;
-        let fixture = config_dir.get_fixture_mut("config.toml")?;
+        let fixture = config_dir.get_file_mut("config.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_repos_config().return_const(fixture.as_path().into());
         locator.expect_hooks_config().return_const(fixture.as_path().into());
@@ -529,7 +531,7 @@ mod tests {
         T: Config<Entry = E>,
     {
         let config_dir = config_dir?;
-        let fixture = config_dir.get_fixture("config.toml")?;
+        let fixture = config_dir.get_file("config.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_repos_config().return_const(fixture.as_path().into());
         locator.expect_hooks_config().return_const(fixture.as_path().into());
@@ -549,7 +551,7 @@ mod tests {
         #[case] config_kind: impl Config,
     ) -> Result<()> {
         let config_dir = config_dir?;
-        let fixture = config_dir.get_fixture("config.toml")?;
+        let fixture = config_dir.get_file("config.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_repos_config().return_const(fixture.as_path().into());
         locator.expect_hooks_config().return_const(fixture.as_path().into());
@@ -580,7 +582,7 @@ mod tests {
         T: Config<Entry = E>,
     {
         let mut config_dir = config_dir?;
-        let fixture = config_dir.get_fixture_mut("config.toml")?;
+        let fixture = config_dir.get_file_mut("config.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_repos_config().return_const(fixture.as_path().into());
         locator.expect_hooks_config().return_const(fixture.as_path().into());
@@ -621,7 +623,7 @@ mod tests {
         T: Config<Entry = E>,
     {
         let mut config_dir = config_dir?;
-        let fixture = config_dir.get_fixture_mut("config.toml")?;
+        let fixture = config_dir.get_file_mut("config.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_repos_config().return_const(fixture.as_path().into());
         locator.expect_hooks_config().return_const(fixture.as_path().into());
@@ -644,7 +646,7 @@ mod tests {
         #[case] config_kind: impl Config,
     ) -> Result<()> {
         let mut config_dir = config_dir?;
-        let fixture = config_dir.get_fixture_mut("not_table.toml")?;
+        let fixture = config_dir.get_file_mut("not_table.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_repos_config().return_const(fixture.as_path().into());
         locator.expect_hooks_config().return_const(fixture.as_path().into());
@@ -682,7 +684,7 @@ mod tests {
         T: Config<Entry = E>,
     {
         let mut config_dir = config_dir?;
-        let fixture = config_dir.get_fixture_mut("config.toml")?;
+        let fixture = config_dir.get_file_mut("config.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_repos_config().return_const(fixture.as_path().into());
         locator.expect_hooks_config().return_const(fixture.as_path().into());
@@ -705,7 +707,7 @@ mod tests {
         #[case] config_kind: impl Config,
     ) -> Result<()> {
         let config_dir = config_dir?;
-        let fixture = config_dir.get_fixture("not_table.toml")?;
+        let fixture = config_dir.get_file("not_table.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_repos_config().return_const(fixture.as_path().into());
         locator.expect_hooks_config().return_const(fixture.as_path().into());
@@ -741,7 +743,7 @@ mod tests {
         T: Config<Entry = E>,
     {
         let mut config_dir = config_dir?;
-        let fixture = config_dir.get_fixture_mut("config.toml")?;
+        let fixture = config_dir.get_file_mut("config.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_repos_config().return_const(fixture.as_path().into());
         locator.expect_hooks_config().return_const(fixture.as_path().into());
@@ -764,7 +766,7 @@ mod tests {
         #[case] config_kind: impl Config,
     ) -> Result<()> {
         let config_dir = config_dir?;
-        let fixture = config_dir.get_fixture("not_table.toml")?;
+        let fixture = config_dir.get_file("not_table.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_repos_config().return_const(fixture.as_path().into());
         locator.expect_hooks_config().return_const(fixture.as_path().into());

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -355,10 +355,12 @@ impl HookPager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cli::Cli;
-    use crate::context::Context;
-    use crate::locate::MockLocator;
-    use crate::testenv::{FixtureHarness, FileKind};
+    use crate::{
+        cli::Cli,
+        context::Context,
+        locate::MockLocator,
+        testenv::{FixtureHarness, FileKind},
+    };
 
     use anyhow::Result;
     use indoc::{formatdoc, indoc};
@@ -370,7 +372,7 @@ mod tests {
         let harness = FixtureHarness::open()?;
         let root = harness.as_path().to_path_buf();
         let harness = harness
-            .with_fixture("hooks.toml", |fixture| {
+            .with_file("hooks.toml", |fixture| {
                 fixture
                     .with_data(indoc! {r#"
                         [hooks]
@@ -381,7 +383,7 @@ mod tests {
                     "#})
                     .with_kind(FileKind::Normal)
             })
-            .with_fixture("hooks/pre_hook.sh", |fixture| {
+            .with_file("hooks/pre_hook.sh", |fixture| {
                 fixture
                     .with_data(formatdoc! {r#"
                         #!/bin/sh
@@ -391,7 +393,7 @@ mod tests {
                     "#, root.display()})
                     .with_kind(FileKind::Script)
             })
-            .with_fixture("hooks/post_hook.sh", |fixture| {
+            .with_file("hooks/post_hook.sh", |fixture| {
                 fixture
                     .with_data(formatdoc! {r#"
                         #!/bin/sh
@@ -401,7 +403,7 @@ mod tests {
                     "#, root.display()})
                     .with_kind(FileKind::Script)
             })
-            .with_fixture("bad_hooks.toml", |fixture| {
+            .with_file("bad_hooks.toml", |fixture| {
                 fixture.with_data("should 'fail'").with_kind(FileKind::Normal)
             })
             .setup()?;
@@ -411,7 +413,7 @@ mod tests {
     #[rstest]
     fn cmd_hook_load_parses_config_file(config_dir: Result<FixtureHarness>) -> Result<()> {
         let config_dir = config_dir?;
-        let fixture = config_dir.get_fixture("hooks.toml")?;
+        let fixture = config_dir.get_file("hooks.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_hooks_config().return_const(fixture.as_path().into());
         locator.expect_hooks_dir().return_const(config_dir.as_path().join("hooks"));
@@ -425,7 +427,7 @@ mod tests {
     #[rstest]
     fn cmd_hook_load_return_err_config_file(config_dir: Result<FixtureHarness>) -> Result<()> {
         let config_dir = config_dir?;
-        let fixture = config_dir.get_fixture("bad_hooks.toml")?;
+        let fixture = config_dir.get_file("bad_hooks.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_hooks_config().return_const(fixture.as_path().into());
         locator.expect_hooks_dir().return_const(config_dir.as_path().join("hooks"));
@@ -446,7 +448,7 @@ mod tests {
         #[case] expect: &str,
     ) -> Result<()> {
         let mut config_dir = config_dir?;
-        let fixture = config_dir.get_fixture("hooks.toml")?;
+        let fixture = config_dir.get_file("hooks.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_hooks_config().return_const(fixture.as_path().into());
         locator.expect_hooks_dir().return_const(config_dir.as_path().join("hooks"));
@@ -455,7 +457,7 @@ mod tests {
         let cmd_hook = CmdHook::load(&ctx, &locator)?;
         cmd_hook.run_hooks(hook_kind)?;
         config_dir.sync_all()?;
-        let result = config_dir.get_fixture("out.txt")?;
+        let result = config_dir.get_file("out.txt")?;
         assert_eq!(result.as_str(), expect);
 
         Ok(())
@@ -469,7 +471,7 @@ mod tests {
         #[case] hook_kind: HookKind,
     ) -> Result<()> {
         let config_dir = config_dir?;
-        let fixture = config_dir.get_fixture("hooks.toml")?;
+        let fixture = config_dir.get_file("hooks.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_hooks_config().return_const(fixture.as_path().into());
         locator.expect_hooks_dir().return_const(config_dir.as_path().join("hooks"));
@@ -489,7 +491,7 @@ mod tests {
         #[case] hook_kind: HookKind,
     ) -> Result<()> {
         let config_dir = config_dir?;
-        let fixture = config_dir.get_fixture("hooks.toml")?;
+        let fixture = config_dir.get_file("hooks.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_hooks_config().return_const(fixture.as_path().into());
         locator.expect_hooks_dir().return_const(config_dir.as_path().join("hooks"));

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -358,7 +358,7 @@ mod tests {
     use crate::cli::Cli;
     use crate::context::Context;
     use crate::locate::MockLocator;
-    use crate::testenv::{FixtureHarness, FixtureKind};
+    use crate::testenv::{FixtureHarness, FileKind};
 
     use anyhow::Result;
     use indoc::{formatdoc, indoc};
@@ -370,42 +370,39 @@ mod tests {
         let harness = FixtureHarness::open()?;
         let root = harness.as_path().to_path_buf();
         let harness = harness
-            .with_file_set(|clump| {
-                clump
-                    .with_fixture("hooks.toml", |fixture| {
-                        fixture
-                            .with_data(indoc! {r#"
-                                [hooks]
-                                bootstrap = [
-                                    { pre = "pre_hook.sh" },
-                                    { post = "post_hook.sh" },
-                                ]
-                            "#})
-                            .with_kind(FixtureKind::NormalFile)
-                    })
-                    .with_fixture("hooks/pre_hook.sh", |fixture| {
-                        fixture
-                            .with_data(formatdoc! {r#"
-                                #!/bin/sh
+            .with_fixture("hooks.toml", |fixture| {
+                fixture
+                    .with_data(indoc! {r#"
+                        [hooks]
+                        bootstrap = [
+                            { pre = "pre_hook.sh" },
+                            { post = "post_hook.sh" },
+                        ]
+                    "#})
+                    .with_kind(FileKind::Normal)
+            })
+            .with_fixture("hooks/pre_hook.sh", |fixture| {
+                fixture
+                    .with_data(formatdoc! {r#"
+                        #!/bin/sh
 
-                                echo "hello from pre hook" > {}/out.txt
-                                exit 0
-                            "#, root.display()})
-                            .with_kind(FixtureKind::ScriptFile)
-                    })
-                    .with_fixture("hooks/post_hook.sh", |fixture| {
-                        fixture
-                            .with_data(formatdoc! {r#"
-                                #!/bin/sh
+                        echo "hello from pre hook" > {}/out.txt
+                        exit 0
+                    "#, root.display()})
+                    .with_kind(FileKind::Script)
+            })
+            .with_fixture("hooks/post_hook.sh", |fixture| {
+                fixture
+                    .with_data(formatdoc! {r#"
+                        #!/bin/sh
 
-                                echo "hello from post hook" > {}/out.txt
-                                exit 0
-                            "#, root.display()})
-                            .with_kind(FixtureKind::ScriptFile)
-                    })
-                    .with_fixture("bad_hooks.toml", |fixture| {
-                        fixture.with_data("should 'fail'").with_kind(FixtureKind::NormalFile)
-                    })
+                        echo "hello from post hook" > {}/out.txt
+                        exit 0
+                    "#, root.display()})
+                    .with_kind(FileKind::Script)
+            })
+            .with_fixture("bad_hooks.toml", |fixture| {
+                fixture.with_data("should 'fail'").with_kind(FileKind::Normal)
             })
             .setup()?;
         Ok(harness)

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -402,14 +402,14 @@ mod tests {
                 FixtureKind::ScriptFile,
             )
             .with_file("bad_hooks.toml", "should 'fail'", FixtureKind::NormalFile)
-            .write()?;
+            .setup()?;
         Ok(fake_dir)
     }
 
     #[rstest]
     fn cmd_hook_load_parses_config_file(config_dir: Result<FakeDir>) -> Result<()> {
         let config_dir = config_dir?;
-        let fixture = config_dir.get_fixture("hooks.toml")?;
+        let fixture = config_dir.fixture("hooks.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_hooks_config().return_const(fixture.as_path().into());
         locator.expect_hooks_dir().return_const(config_dir.as_path().join("hooks"));
@@ -423,7 +423,7 @@ mod tests {
     #[rstest]
     fn cmd_hook_load_return_err_config_file(config_dir: Result<FakeDir>) -> Result<()> {
         let config_dir = config_dir?;
-        let fixture = config_dir.get_fixture("bad_hooks.toml")?;
+        let fixture = config_dir.fixture("bad_hooks.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_hooks_config().return_const(fixture.as_path().into());
         locator.expect_hooks_dir().return_const(config_dir.as_path().join("hooks"));
@@ -444,7 +444,7 @@ mod tests {
         #[case] expect: &str,
     ) -> Result<()> {
         let mut config_dir = config_dir?;
-        let fixture = config_dir.get_fixture("hooks.toml")?;
+        let fixture = config_dir.fixture("hooks.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_hooks_config().return_const(fixture.as_path().into());
         locator.expect_hooks_dir().return_const(config_dir.as_path().join("hooks"));
@@ -453,7 +453,7 @@ mod tests {
         let cmd_hook = CmdHook::load(&ctx, &locator)?;
         cmd_hook.run_hooks(hook_kind)?;
         config_dir.sync()?;
-        let result = config_dir.get_fixture("out.txt")?;
+        let result = config_dir.fixture("out.txt")?;
         assert_eq!(result.as_str(), expect);
 
         Ok(())
@@ -467,7 +467,7 @@ mod tests {
         #[case] hook_kind: HookKind,
     ) -> Result<()> {
         let config_dir = config_dir?;
-        let fixture = config_dir.get_fixture("hooks.toml")?;
+        let fixture = config_dir.fixture("hooks.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_hooks_config().return_const(fixture.as_path().into());
         locator.expect_hooks_dir().return_const(config_dir.as_path().join("hooks"));
@@ -487,7 +487,7 @@ mod tests {
         #[case] hook_kind: HookKind,
     ) -> Result<()> {
         let config_dir = config_dir?;
-        let fixture = config_dir.get_fixture("hooks.toml")?;
+        let fixture = config_dir.fixture("hooks.toml")?;
         let mut locator = MockLocator::new();
         locator.expect_hooks_config().return_const(fixture.as_path().into());
         locator.expect_hooks_dir().return_const(config_dir.as_path().join("hooks"));

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -359,7 +359,7 @@ mod tests {
         cli::Cli,
         context::Context,
         locate::MockLocator,
-        testenv::{FixtureHarness, FileKind},
+        testenv::{FileKind, FixtureHarness},
     };
 
     use anyhow::Result;
@@ -456,7 +456,7 @@ mod tests {
         let ctx = Context::from(Cli::parse_args(["ricer", "--run-hook=always", "bootstrap"])?);
         let cmd_hook = CmdHook::load(&ctx, &locator)?;
         cmd_hook.run_hooks(hook_kind)?;
-        config_dir.sync_all()?;
+        config_dir.sync_untracked()?;
         let result = config_dir.get_file("out.txt")?;
         assert_eq!(result.as_str(), expect);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ pub mod config;
 pub mod context;
 pub mod hook;
 pub mod locate;
+pub mod vcs;
 
 #[cfg(test)]
 pub mod testenv;

--- a/src/testenv.rs
+++ b/src/testenv.rs
@@ -14,106 +14,43 @@ use tempfile::{Builder as TempFileBuilder, TempDir};
 use walkdir::WalkDir;
 
 pub struct FixtureHarness {
-    dir: TempDir,
-    fixtures: FixtureClump,
+    root: TempDir,
+    fixtures: HashMap<PathBuf, FileFixture>,
 }
 
 impl FixtureHarness {
     pub fn open() -> Result<Self> {
-        let dir = TempFileBuilder::new().tempdir()?;
-        Ok(Self { dir, fixtures: FixtureClump::default() })
+        let root = TempFileBuilder::new().tempdir()?;
+        Ok(Self { root, fixtures: HashMap::new() })
     }
 
-    pub fn with_file_set<F>(mut self, callback: F) -> Self
-    where
-        F: FnOnce(FixtureClump) -> FixtureClump,
-    {
-        self.fixtures = callback(FixtureClump::new(self.dir.path()));
+    pub fn with_fixture(
+        mut self,
+        path: impl AsRef<Path>,
+        callback: impl FnOnce(FileFixture) -> FileFixture
+    ) -> Self {
+        let fixture = callback(FileFixture::new(self.root.path().join(path.as_ref())));
+        self.fixtures.insert(fixture.as_path().into(), fixture);
         self
     }
 
     pub fn setup(self) -> Result<Self> {
-        self.fixtures.write_all()?;
-        Ok(self)
-    }
-
-    pub fn get_fixture(&self, name: impl AsRef<Path>) -> Result<&Fixture> {
-        self.fixtures.get(name.as_ref())
-    }
-
-    pub fn get_fixture_mut(&mut self, name: impl AsRef<Path>) -> Result<&mut Fixture> {
-        self.fixtures.get_mut(name.as_ref())
-    }
-
-    pub fn sync_all(&mut self) -> Result<()> {
-        self.fixtures.sync_all()?;
-
-        // Track any new files that were added by some external process(es)...
-        for entry in WalkDir::new(self.dir.path()).into_iter().filter_map(Result::ok) {
-            // INVARIANT: only add in a _file_ that is not being tracked.
-            if entry.file_type().is_file() && !self.fixtures.is_tracked(entry.path()) {
-                let path = entry.path().to_path_buf();
-                let data = read_to_string(&path)?;
-                let kind = match path.is_executable() {
-                    true => FixtureKind::ScriptFile,
-                    false => FixtureKind::NormalFile,
-                };
-                let fixture = Fixture::new(path).with_data(data).with_kind(kind);
-                self.fixtures.insert(fixture);
-            }
-        }
-
-        Ok(())
-    }
-
-    pub fn as_path(&self) -> &Path {
-        self.dir.path()
-    }
-}
-
-#[derive(Debug, Default, Clone)]
-pub struct FixtureClump {
-    root: PathBuf,
-    fixtures: HashMap<PathBuf, Fixture>,
-}
-
-impl FixtureClump {
-    pub fn new(path: impl Into<PathBuf>) -> Self {
-        Self { root: path.into(), fixtures: HashMap::new() }
-    }
-
-    pub fn with_fixture<F, P>(mut self, path: P, callback: F) -> Self
-    where
-        F: FnOnce(Fixture) -> Fixture,
-        P: AsRef<Path>,
-    {
-        let fixture = callback(Fixture::new(self.root.join(path.as_ref())));
-        self.fixtures.insert(fixture.as_path().into(), fixture);
-        self
-    }
-
-    pub fn insert(&mut self, fixture: Fixture) {
-        self.fixtures.insert(fixture.as_path().into(), fixture);
-    }
-
-    pub fn get(&self, path: impl AsRef<Path>) -> Result<&Fixture> {
-        self.fixtures
-            .get(&self.root.join(path.as_ref()))
-            .ok_or(anyhow!("Fixture '{}' not in clump", path.as_ref().display()))
-    }
-
-    pub fn get_mut(&mut self, path: impl AsRef<Path>) -> Result<&mut Fixture> {
-        self.fixtures
-            .get_mut(&self.root.join(path.as_ref()))
-            .ok_or(anyhow!("Fixture '{}' not in clump", path.as_ref().display()))
-    }
-
-    pub fn write_all(&self) -> Result<()> {
         for (_, fixture) in self.fixtures.iter() {
             fixture.write()?;
         }
+        Ok(self)
+    }
 
-        Ok(())
+    pub fn get_fixture(&self, path: impl AsRef<Path>) -> Result<&FileFixture> {
+        self.fixtures
+            .get(&self.root.path().join(path.as_ref()))
+            .ok_or(anyhow!("Fixture '{}' not in fixture harness", path.as_ref().display()))
+    }
+
+    pub fn get_fixture_mut(&mut self, path: impl AsRef<Path>) -> Result<&mut FileFixture> {
+        self.fixtures
+            .get_mut(&self.root.path().join(path.as_ref()))
+            .ok_or(anyhow!("Fixture '{}' not in fixture harness", path.as_ref().display()))
     }
 
     pub fn sync_all(&mut self) -> Result<()> {
@@ -121,22 +58,37 @@ impl FixtureClump {
             fixture.sync()?;
         }
 
+        // Track any new files that were added by some external process(es)...
+        for entry in WalkDir::new(self.root.path()).into_iter().filter_map(Result::ok) {
+            // INVARIANT: only add in a _file_ that is not being tracked.
+            if entry.file_type().is_file() && !self.fixtures.contains_key(entry.path()) {
+                let path = entry.path().to_path_buf();
+                let data = read_to_string(&path)?;
+                let kind = match path.is_executable() {
+                    true => FileKind::Script,
+                    false => FileKind::Normal,
+                };
+                let fixture = FileFixture::new(path.clone()).with_data(data).with_kind(kind);
+                self.fixtures.insert(path, fixture);
+            }
+        }
+
         Ok(())
     }
 
-    pub fn is_tracked(&self, path: impl AsRef<Path>) -> bool {
-        self.fixtures.contains_key(path.as_ref())
+    pub fn as_path(&self) -> &Path {
+        self.root.path()
     }
 }
 
 #[derive(Debug, Default, Clone)]
-pub struct Fixture {
+pub struct FileFixture {
     path: PathBuf,
     data: String,
-    kind: FixtureKind,
+    kind: FileKind,
 }
 
-impl Fixture {
+impl FileFixture {
     pub fn new(path: impl Into<PathBuf>) -> Self {
         Self { path: path.into(), data: Default::default(), kind: Default::default() }
     }
@@ -146,7 +98,7 @@ impl Fixture {
         self
     }
 
-    pub fn with_kind(mut self, kind: FixtureKind) -> Self {
+    pub fn with_kind(mut self, kind: FileKind) -> Self {
         self.kind = kind;
         self
     }
@@ -156,7 +108,7 @@ impl Fixture {
         write(&self.path, &self.data)?;
 
         #[cfg(unix)]
-        if self.kind == FixtureKind::ScriptFile {
+        if self.kind == FileKind::Script {
             use std::os::unix::fs::PermissionsExt;
 
             let metadata = metadata(&self.path)?;
@@ -178,7 +130,7 @@ impl Fixture {
     }
 
     pub fn is_executable(&self) -> bool {
-        self.kind == FixtureKind::ScriptFile
+        self.kind == FileKind::Script
     }
 
     pub fn sync(&mut self) -> Result<()> {
@@ -188,9 +140,9 @@ impl Fixture {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub enum FixtureKind {
+pub enum FileKind {
     #[default]
-    NormalFile,
+    Normal,
 
-    ScriptFile,
+    Script,
 }

--- a/src/vcs.rs
+++ b/src/vcs.rs
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
+// SPDX-License-Identifier: MIT
+
+use git2::{Error as Git2Error, Repository};
+use std::path::Path;
+
+pub struct GitRepo {
+    repo: Repository,
+}
+
+impl GitRepo {
+    /// Create new Git repository at `path`.
+    ///
+    /// Will create any necessary directories to repository.
+    ///
+    /// # Errors
+    ///
+    /// - Return [`GitRepoError::LibGit2`] if repository cannot be created.
+    pub fn init(path: impl AsRef<Path>) -> Result<Self, GitRepoError> {
+        todo!();
+    }
+
+    pub fn is_fake_bare(&self) -> bool {
+        todo!();
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum GitRepoError {
+    #[error("Failed to perform libgit2 operation")]
+    LibGit2 { source: Git2Error },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testenv::FakeDir;
+
+    use anyhow::Result;
+    use rstest::{fixture, rstest};
+
+    #[fixture]
+    fn repo_dir() -> Result<FakeDir> {
+        let fake = FakeDir::open()?;
+        Ok(fake)
+    }
+
+    #[rstest]
+    fn git_repo_init_return_self(repo_dir: Result<FakeDir>) -> Result<()> {
+        let repo_dir = repo_dir?;
+        let repo = GitRepo::init(repo_dir.as_path().join("foo"))?;
+        assert!(!repo.is_fake_bare());
+        Ok(())
+    }
+}

--- a/src/vcs.rs
+++ b/src/vcs.rs
@@ -21,6 +21,17 @@ impl GitRepo {
         Ok(Self { repo })
     }
 
+    /// Create new Git repository that uses fake bare technique at `path`.
+    ///
+    /// Will create any necessary directories to fake bare repository.
+    ///
+    /// # Errors
+    ///
+    /// - Return [`GitRepoError::LibGit2`] if repository cannot be created.
+    pub fn init_fake_bare(path: impl AsRef<Path>) -> Result<Self, GitRepoError> {
+        todo!();
+    }
+
     pub fn is_fake_bare(&self) -> bool {
         !self.repo.is_bare() && !self.repo.path().to_string_lossy().into_owned().contains(".git")
     }
@@ -57,6 +68,14 @@ mod tests {
         let repo_dir = repo_dir?;
         let repo = GitRepo::init(repo_dir.as_path().join("foo"))?;
         assert!(!repo.is_fake_bare());
+        Ok(())
+    }
+
+    #[rstest]
+    fn git_repo_init_fake_bare_return_self(repo_dir: Result<FakeDir>) -> Result<()> {
+        let repo_dir = repo_dir?;
+        let repo = GitRepo::init(repo_dir.as_path().join("foo"))?;
+        assert!(repo.is_fake_bare());
         Ok(())
     }
 }

--- a/src/vcs.rs
+++ b/src/vcs.rs
@@ -73,7 +73,7 @@ impl From<Git2Error> for GitRepoError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::testenv::{FixtureHarness, FixtureKind};
+    use crate::testenv::{FixtureHarness, FileKind};
 
     use anyhow::Result;
     use indoc::indoc;

--- a/src/vcs.rs
+++ b/src/vcs.rs
@@ -22,7 +22,7 @@ impl GitRepo {
     }
 
     pub fn is_fake_bare(&self) -> bool {
-        todo!();
+        !self.repo.is_bare() && !self.repo.path().to_string_lossy().into_owned().contains(".git")
     }
 }
 

--- a/src/vcs.rs
+++ b/src/vcs.rs
@@ -176,10 +176,10 @@ impl GitRepo {
         !self.repo.is_bare() && !self.repo.path().ends_with(".git")
     }
 
-    pub(crate) fn fetch<'git>(
+    pub(crate) fn fetch(
         &self,
         refs: &[&str],
-        remote: &'git mut Remote,
+        remote: &mut Remote,
     ) -> Result<AnnotatedCommit, GitRepoError> {
         let mut cb = RemoteCallbacks::new();
 

--- a/src/vcs.rs
+++ b/src/vcs.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
 // SPDX-License-Identifier: MIT
 
-use git2::{Error as Git2Error, Repository};
+use git2::{Error as Git2Error, Repository, RepositoryInitOptions};
 use std::path::Path;
 
 pub struct GitRepo {
@@ -28,8 +28,17 @@ impl GitRepo {
     /// # Errors
     ///
     /// - Return [`GitRepoError::LibGit2`] if repository cannot be created.
-    pub fn init_fake_bare(path: impl AsRef<Path>) -> Result<Self, GitRepoError> {
-        todo!();
+    pub fn init_fake_bare(
+        gitdir: impl AsRef<Path>,
+        workdir: impl AsRef<Path>,
+    ) -> Result<Self, GitRepoError> {
+        let mut opts = RepositoryInitOptions::new();
+        opts.bare(false);
+        opts.no_dotgit_dir(true);
+        opts.workdir_path(workdir.as_ref());
+
+        let repo = Repository::init_opts(gitdir.as_ref(), &opts)?;
+        Ok(Self { repo })
     }
 
     pub fn is_fake_bare(&self) -> bool {
@@ -74,7 +83,7 @@ mod tests {
     #[rstest]
     fn git_repo_init_fake_bare_return_self(repo_dir: Result<FakeDir>) -> Result<()> {
         let repo_dir = repo_dir?;
-        let repo = GitRepo::init(repo_dir.as_path().join("foo"))?;
+        let repo = GitRepo::init_fake_bare(repo_dir.as_path().join("foo"), repo_dir.as_path())?;
         assert!(repo.is_fake_bare());
         Ok(())
     }

--- a/src/vcs.rs
+++ b/src/vcs.rs
@@ -17,7 +17,8 @@ impl GitRepo {
     ///
     /// - Return [`GitRepoError::LibGit2`] if repository cannot be created.
     pub fn init(path: impl AsRef<Path>) -> Result<Self, GitRepoError> {
-        todo!();
+        let repo = Repository::init(path.as_ref())?;
+        Ok(Self { repo })
     }
 
     pub fn is_fake_bare(&self) -> bool {
@@ -29,6 +30,12 @@ impl GitRepo {
 pub enum GitRepoError {
     #[error("Failed to perform libgit2 operation")]
     LibGit2 { source: Git2Error },
+}
+
+impl From<Git2Error> for GitRepoError {
+    fn from(err: Git2Error) -> Self {
+        GitRepoError::LibGit2 { source: err }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Jason Pena <jasonpena@awkless.com>
SPDX-License-Identifier: MIT
-->

## Description

This pull request allows Ricer's code base to handle Git repository operations through `ricer::vcs::GitRepo`.

What do your changes do?

## Area of Effect

- Module `ricer::vcs`.
- Module `ricer::testenv`.

## Tasks

- [x] Refactor `ricer::testenv` to allow for Git repository fixtures.
- [x] Add `GitRepo::init`.
- [x] Add `GitRepo::init_fake_bare`
- [x] Add `GitRepo::open`
- [x] Add `GitRepo::pull`
- [x] Add `GitRepo::push`
- [x] Add `GitRepo::clone`
